### PR TITLE
feat: Allow .json files in file editor API

### DIFF
--- a/lambda/file-editor/index.py
+++ b/lambda/file-editor/index.py
@@ -15,7 +15,7 @@ PASSPHRASE_HASH = os.environ["PASSPHRASE_HASH"]
 ALLOWED_ORIGIN = os.environ.get("ALLOWED_ORIGIN", "https://xomware.com")
 
 # Only allow .md files, no path traversal
-ALLOWED_EXTENSIONS = {".md"}
+ALLOWED_EXTENSIONS = {".md", ".json"}
 MAX_FILE_SIZE = 100_000  # 100KB
 
 


### PR DESCRIPTION
Adds .json to the allowed file extensions so agent-status.json can be managed through the API (for the live Pixel Office).