### PR TITLE
feat: Migrate from Terraform Cloud to S3 backend

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,79 @@
+name: Terraform
+
+on:
+  push:
+    branches: [master]
+    paths: ['terraform/**', 'lambda/**']
+  pull_request:
+    branches: [master]
+    paths: ['terraform/**', 'lambda/**']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TF_DIR: terraform
+  AWS_REGION: us-east-1
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.TF_DIR }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+        env:
+          TF_VAR_command_center_passphrase_hash: ${{ secrets.COMMAND_CENTER_PASSPHRASE_HASH }}
+
+      - name: Comment PR with Plan
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const plan = `${{ steps.plan.outputs.stdout }}`;
+            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n\n... (truncated)' : plan;
+            const body = `### Terraform Plan 📋
+            \`\`\`
+            ${truncated}
+            \`\`\`
+            *Plan: ${{ steps.plan.outcome }}*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false
+        env:
+          TF_VAR_command_center_passphrase_hash: ${{ secrets.COMMAND_CENTER_PASSPHRASE_HASH }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Terraform
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.auto.tfvars
+
+# Lambda packages
+lambda/**/*.zip

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  backend "remote" {
-    organization = "Domjgiordano"
-
-    workspaces {
-      name = "xomware-infrastructure"
-    }
+  backend "s3" {
+    bucket         = "xomware-terraform-state"
+    key            = "xomware/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "xomware-terraform-locks"
+    encrypt        = true
   }
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.access_key
-  secret_key = var.secret_key
-  region     = var.aws_region
+  region = var.aws_region
+  # Auth via AWS CLI profile, env vars (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY),
+  # or IAM role. No hardcoded credentials.
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy to terraform.tfvars and fill in values
+# terraform.tfvars is gitignored — never commit secrets
+
+command_center_passphrase_hash = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,18 +4,6 @@ variable "app_name" {
   default     = "xomware"
 }
 
-variable "access_key" {
-  description = "AWS access key."
-  type        = string
-  sensitive   = true
-}
-
-variable "secret_key" {
-  description = "AWS secret key."
-  type        = string
-  sensitive   = true
-}
-
 variable "domain_suffix" {
   description = "Suffix for the domain of the app."
   type        = string


### PR DESCRIPTION
## Summary
Migrates xomware-infrastructure from Terraform Cloud to self-managed S3 state backend.

## Changes
- **Backend:** `remote` → `s3` (bucket: `xomware-terraform-state`, key: `xomware/terraform.tfstate`)
- **State locking:** DynamoDB table `xomware-terraform-locks`
- **Provider auth:** Removed hardcoded `access_key`/`secret_key` vars — uses AWS CLI profile or env vars
- **CI/CD:** GitHub Actions workflow (`terraform plan` on PR, `terraform apply` on merge)
- **Security:** Added `.gitignore` for state files, `.terraform/`, and `terraform.tfvars`

## Before Merging
1. **Upload state to S3:**
   ```bash
   aws s3 cp terraform-migration/xomware-infrastructure.tfstate s3://xomware-terraform-state/xomware/terraform.tfstate
   ```
2. **Set GitHub repo secrets** (Settings → Secrets → Actions):
   - `AWS_ACCESS_KEY_ID`
   - `AWS_SECRET_ACCESS_KEY`
   - `COMMAND_CENTER_PASSPHRASE_HASH`
3. Merge this PR
4. Verify: GitHub Actions runs `terraform plan` with no changes

## Part of
Terraform Cloud → S3 migration (this is the first repo, 44 resources). Will repeat for xomper, xomcloud, xomify.