### PR TITLE
cost: shared WAF consolidation (8 ACLs → 2)

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,12 +1,42 @@
 #**********************
-# WAF (via reusable module)
+# Shared WAF (via reusable module)
+# These WAFs are shared across all Xomware apps
+# ARNs are exported via SSM for child repos to consume
 #**********************
 
-# CloudFront WAF
+# Shared CloudFront WAF (protects all app CloudFront distributions)
 module "waf_cloudfront" {
   source = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
 
-  app_name = "${var.app_name}-cloudfront"
+  app_name = "xomware-shared-cloudfront"
   scope    = "CLOUDFRONT"
   tags     = local.standard_tags
+}
+
+# Shared Regional WAF (protects all app API Gateways)
+module "waf_regional" {
+  source = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
+
+  app_name   = "xomware-shared-regional"
+  scope      = "REGIONAL"
+  rate_limit = 2000
+  tags       = local.standard_tags
+}
+
+#**********************
+# SSM Parameters (for child repos to consume)
+#**********************
+
+resource "aws_ssm_parameter" "shared_cloudfront_waf_arn" {
+  name  = "/xomware/shared/cloudfront-waf-acl-arn"
+  type  = "String"
+  value = module.waf_cloudfront.web_acl_arn
+  tags  = local.standard_tags
+}
+
+resource "aws_ssm_parameter" "shared_regional_waf_arn" {
+  name  = "/xomware/shared/regional-waf-acl-arn"
+  type  = "String"
+  value = module.waf_regional.web_acl_arn
+  tags  = local.standard_tags
 }


### PR DESCRIPTION
## Summary
- Rename CloudFront WAF to `xomware-shared-cloudfront` (shared across all apps)
- Add shared Regional WAF `xomware-shared-regional` with rate limit 2000 (for all API Gateways)
- Export both WAF ACL ARNs via SSM Parameter Store (`/xomware/shared/cloudfront-waf-acl-arn` and `/xomware/shared/regional-waf-acl-arn`)
- Child repos (xomify, xomcloud, xomper, meals) will consume these instead of deploying their own WAFs

## Cost Impact
- **Before:** 8 WAF Web ACLs (~$58/month)
- **After:** 2 WAF Web ACLs (~$14/month)
- **Savings:** ~$44/month (~75% reduction)

## Deploy Order
1. **This PR first** — creates shared WAFs + SSM params
2. Then child repo PRs — remove local WAFs, consume shared ARNs

## Test plan
- [ ] `terraform plan` shows 3 new resources (regional WAF + 2 SSM params) and 1 modified (CloudFront WAF name change)
- [ ] After apply, verify SSM params exist in AWS console
- [ ] Verify xomware.com CloudFront still has WAF protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)