### PR TITLE
fix: WAF deploy issues (name + SSM tags)

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -8,7 +8,7 @@
 module "waf_cloudfront" {
   source = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
 
-  app_name = "xomware-shared-cloudfront"
+  app_name = "${var.app_name}-cloudfront"
   scope    = "CLOUDFRONT"
   tags     = local.standard_tags
 }
@@ -17,7 +17,7 @@ module "waf_cloudfront" {
 module "waf_regional" {
   source = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
 
-  app_name   = "xomware-shared-regional"
+  app_name   = "${var.app_name}-regional"
   scope      = "REGIONAL"
   rate_limit = 2000
   tags       = local.standard_tags
@@ -31,12 +31,10 @@ resource "aws_ssm_parameter" "shared_cloudfront_waf_arn" {
   name  = "/xomware/shared/cloudfront-waf-acl-arn"
   type  = "String"
   value = module.waf_cloudfront.web_acl_arn
-  tags  = local.standard_tags
 }
 
 resource "aws_ssm_parameter" "shared_regional_waf_arn" {
   name  = "/xomware/shared/regional-waf-acl-arn"
   type  = "String"
   value = module.waf_regional.web_acl_arn
-  tags  = local.standard_tags
 }


### PR DESCRIPTION
## Summary
- Revert CloudFront WAF `app_name` back to `${var.app_name}-cloudfront` to avoid destroy/recreate (CloudFront still references the old ACL)
- Remove `tags` from SSM parameters to avoid `ssm:AddTagsToResource` permission error on jarvis-agent

## Context
The previous PR renamed the WAF which triggered a destroy+recreate cycle. AWS can't delete a WAF ACL that's still associated with a CloudFront distribution. This fix keeps the original name so Terraform treats it as a no-op on the existing CloudFront WAF.

## Test plan
- [ ] `terraform plan` shows only new resources (regional WAF + 2 SSM params), no destroys on CloudFront WAF
- [ ] After apply, both SSM params exist with valid WAF ARNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)