### PR TITLE
docs: add Claude Code config, workflows, and reference docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,18 +1,31 @@
 # xomware-infrastructure
 
-> Main infrastructure repo — hosts all Xomware sites.
+> Core Terraform infrastructure for xomware.com platform hub.
 
 ## What This Is
-Terraform IaC for xomware.com and shared infra. S3, CloudFront, Route53, ACM.
+Terraform configuration for the root Xomware platform infrastructure. Manages the Route53 zone for xomware.com (shared by all Xomware apps), S3 + CloudFront frontend hosting, WAF, TLS certs, and encryption keys.
 
 ## Stack
-- Terraform, HCL, Python (Lambda), AWS
+- Terraform >= 1.0
+- AWS (Route53, S3, CloudFront, WAF, ACM, KMS)
+- S3 backend for state (bucket: xomware-terraform-state)
 
 ## Key Commands
 ```bash
-cd terraform && terraform init
-cd terraform && terraform plan
-cd terraform && terraform apply
+cd terraform && terraform init   # initialize
+terraform plan                   # preview changes
+terraform apply                  # apply changes
+```
+
+## Important Paths
+```
+terraform/          # all .tf files (10 total)
+  main.tf           # provider + backend config
+  route53.tf        # xomware.com DNS zone (SHARED)
+  s3.tf             # S3 + CloudFront hosting
+  waf.tf            # WAF rules
+  kms.tf            # encryption keys
+  acm.tf            # TLS certificates
 ```
 
 ## Project Config
@@ -22,9 +35,16 @@ github_project_number: 2
 github_project_owner: Xomware
 base_branch: master
 test_commands:
-  - echo "no tests configured"
+  - cd terraform && terraform validate
+build_commands:
+  - cd terraform && terraform plan -no-color
 ```
 
 ## Constraints
+- NO infrastructure changes without Dom's explicit approval
+- Route53 zone is shared — changes here affect DNS for ALL Xomware apps
+- State stored in S3 with DynamoDB locking (table: xomware-terraform-locks)
+- CI/CD via GitHub Actions — plan on PR, apply on merge to master
+- WAF module sourced from the shared `waf` repo
 
 ## Lessons

--- a/.claude/prompts/ci-triage.md
+++ b/.claude/prompts/ci-triage.md
@@ -1,0 +1,53 @@
+You are a triage bot. Keep it light — a developer will do deep analysis later via /work-issue.
+
+Read the project's CLAUDE.md to find the `## Project Config` block. Use it for:
+- `base_branch` — which branch to create feature branches from
+- `pm_tool` — whether to create a Notion task
+- Notion field IDs (datasource, project, goal, pillar, assignee) — for task creation
+
+DO NOT:
+- Write or modify any source code
+- Create pull requests or commit code
+- Do deep codebase analysis (no reading file contents, no line numbers)
+- Read source files — just use Glob to confirm files exist
+
+DO:
+1. Read the issue — understand what's being reported (bug, feature, question)
+2. Read CLAUDE.md to get Project Config values
+3. Use Glob to find the likely files involved (just paths, don't read them)
+4. Classify: bug, enhancement, or documentation
+5. Estimate scope: small (1-2 files), medium (3-5 files), large (5+ files)
+6. Add labels using: gh issue edit <number> --add-label <label>
+   - Type: bug, enhancement, or documentation
+   - Priority: P1-critical, P2-high, P3-medium, or P4-low
+7. Create a branch off {base_branch} from Project Config:
+   - Format: {type}/{issue#}-{short-desc}
+   - Types: feature, fix, chore, docs, refactor
+   - Commands: git fetch origin {base_branch} && git checkout -b {branch} origin/{base_branch} && git push origin {branch}
+8. If Notion MCP tools are available AND pm_tool is "notion", create a task:
+   - Use mcp__notion__API-post-page with parent database from Project Config
+   - Set properties from Project Config: Name, Status, Priority, Assignee, Project, Goal, Pillar
+   - Content: brief summary + file list
+   - If permission error, skip and note N/A
+
+Your output is posted as a GitHub issue comment. Use emojis and clean formatting:
+
+### Triage: [issue title]
+
+| | |
+|---|---|
+| **Type** | bug / enhancement / docs |
+| **Priority** | P1-P4 |
+| **Scope** | small / medium / large |
+| **Branch** | `{type}/{issue#}-{short-desc}` |
+| **PM Task** | [task link] or N/A |
+
+**Summary:** [1-2 sentences — what the issue is, not how to fix it]
+
+**Files likely involved:**
+- `path/to/file`
+
+**Recommended approach:** `/fix` / `/plan` / `/brainstorm` — [one line why]
+
+---
+*Auto-triaged. Run `/work-issue {number}` to start.*

--- a/.claude/rules/org.md
+++ b/.claude/rules/org.md
@@ -32,6 +32,11 @@
 - GitHub Actions for CI
 - Deploy on merge to main/master (platform-specific)
 
+## Common Mistakes
+- Committing `.env` files
+- Over-engineering infra for personal projects — start simple, scale when needed
+- Forgetting to update `.env.example` when adding new env vars
+
 ## Deprecated
 - OpenClaw multi-agent framework is deprecated — use Claude Code native workflows
 - Do not create or reference OpenClaw patterns, dispatcher configs, or agent orchestrators

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -1,0 +1,118 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    if: |
+      (github.event_name == 'issues') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Install Claude Code and Notion MCP
+        run: |
+          npm install -g @anthropic-ai/claude-code@latest
+          npm install -g @notionhq/notion-mcp-server
+
+      - name: Set up Notion MCP config
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "NOTION_TOKEN not set, skipping MCP config"
+            exit 0
+          fi
+          cat > /tmp/mcp-config.json << 'MCPEOF'
+          {
+            "mcpServers": {
+              "notion": {
+                "command": "notion-mcp-server",
+                "env": {
+                  "NOTION_TOKEN": "PLACEHOLDER"
+                }
+              }
+            }
+          }
+          MCPEOF
+          sed -i "s|PLACEHOLDER|${NOTION_TOKEN}|g" /tmp/mcp-config.json
+
+      - name: Acknowledge trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content=eyes
+          else
+            gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/reactions -f content=eyes
+          fi
+
+      - name: Get issue info
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUMBER=${{ github.event.issue.number }}
+          TITLE=$(gh issue view $NUMBER --json title -q .title)
+          BODY=$(gh issue view $NUMBER --json body -q .body)
+          echo "number=$NUMBER" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "$BODY" > /tmp/issue-body.txt
+
+      - name: Run Claude triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.DEV_ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          ISSUE_BODY=$(cat /tmp/issue-body.txt)
+          SYSTEM_PROMPT=$(cat .claude/prompts/ci-triage.md)
+
+          # Build MCP flag if config exists
+          MCP_FLAG=""
+          if [ -f /tmp/mcp-config.json ]; then
+            MCP_FLAG="--mcp-config /tmp/mcp-config.json"
+          fi
+
+          # Write the user prompt to a file (avoids ENAMETOOLONG)
+          cat > /tmp/triage-prompt.txt << PROMPTEOF
+          Triage issue #${{ steps.issue.outputs.number }}: ${{ steps.issue.outputs.title }}
+
+          Issue body:
+          $ISSUE_BODY
+
+          Repository is checked out at $(pwd). Analyze the codebase, then:
+          1. Analyze and produce your triage report
+          2. Add labels with: gh issue edit ${{ steps.issue.outputs.number }} --add-label <label>
+          3. Create a branch off the base branch (read from Project Config in CLAUDE.md)
+          4. Create a PM task if Notion MCP is available (read IDs from Project Config in CLAUDE.md)
+          PROMPTEOF
+
+          claude -p "$(cat /tmp/triage-prompt.txt)" \
+            --print \
+            --model claude-sonnet-4-6 \
+            --system-prompt "$SYSTEM_PROMPT" \
+            --max-turns 15 \
+            --allowedTools "Read,Glob,Grep,Bash(git fetch:*),Bash(git checkout:*),Bash(git push:*),Bash(git branch:*),Bash(gh issue edit:*),Bash(gh label create:*),mcp__notion__API-post-page,mcp__notion__API-post-search,mcp__notion__API-retrieve-a-database,mcp__notion__API-query-data-source,mcp__notion__API-retrieve-a-page,mcp__notion__API-patch-page" \
+            $MCP_FLAG > /tmp/triage-output.md
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.issue.outputs.number }} --body-file /tmp/triage-output.md


### PR DESCRIPTION
## Summary
- Add `.claude/` config: CLAUDE.md, settings, rules, and CI triage prompt
- Add GitHub Actions workflow for Claude-powered issue triage
- Add reference docs (agents, commands, file structure, workflows)
- Add workflow guides (feature, epic, research)
- Resolve conflicts with remote master's project management and org config updates

## Test plan
- [ ] Verify `.claude/CLAUDE.md` has correct project config
- [ ] Verify `.claude/rules/org.md` has merged org conventions
- [ ] Confirm no conflict markers remain in any files

🤖 Generated with [Claude Code](https://claude.com/claude-code)