### PR TITLE
Phase 3: users service + migrate file-editor to editor-api.xomware.com

### DIFF
--- a/lambda/users/shared/auth.js
+++ b/lambda/users/shared/auth.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Pull Cognito sub from API Gateway authorizer claims.
+function getUserId(event) {
+  const claims =
+    (event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims) ||
+    null;
+  if (!claims || !claims.sub) return null;
+  return claims.sub;
+}
+
+function getClaims(event) {
+  return (
+    (event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims) ||
+    {}
+  );
+}
+
+module.exports = { getUserId, getClaims };

--- a/lambda/users/shared/dynamo.js
+++ b/lambda/users/shared/dynamo.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const baseClient = new DynamoDBClient({ region });
+const docClient = DynamoDBDocumentClient.from(baseClient, {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+module.exports = { docClient };

--- a/lambda/users/shared/response.js
+++ b/lambda/users/shared/response.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// API Gateway REST API v1 response helper.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function ok(body) {
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+function notFound(message) {
+  return {
+    statusCode: 404,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify({ error: message || 'not_found' }),
+  };
+}
+
+function badRequest(message) {
+  return {
+    statusCode: 400,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify({ error: message || 'bad_request' }),
+  };
+}
+
+function unauthorized(message) {
+  return {
+    statusCode: 401,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify({ error: message || 'unauthorized' }),
+  };
+}
+
+function serverError(message) {
+  return {
+    statusCode: 500,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify({ error: message || 'internal_error' }),
+  };
+}
+
+module.exports = { ok, notFound, badRequest, unauthorized, serverError };

--- a/lambda/users/users-create/index.js
+++ b/lambda/users/users-create/index.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// Cognito PostConfirmation trigger.
+// On email-verified signup, write a user row to xomware-users.
+// Idempotent via attribute_not_exists(userId) condition.
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, PutCommand } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.USERS_TABLE_NAME;
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+exports.handler = async (event) => {
+  // Always return event back to Cognito, even on failure — failing this trigger
+  // blocks the user from signing up. Log and continue; users-me will 404 and
+  // the frontend can retry / handle the missing-row case.
+  try {
+    const triggerSource = event && event.triggerSource;
+    if (
+      triggerSource !== 'PostConfirmation_ConfirmSignUp' &&
+      triggerSource !== 'PostConfirmation_ConfirmForgotPassword'
+    ) {
+      // Ignore other trigger sources (e.g. password reset). Just pass through.
+      return event;
+    }
+
+    const attrs = (event.request && event.request.userAttributes) || {};
+    const userId = attrs.sub;
+    const email = attrs.email;
+    const preferredUsername = attrs.preferred_username || attrs['cognito:username'];
+
+    if (!userId) {
+      console.error('users-create: no sub in userAttributes', attrs);
+      return event;
+    }
+
+    const now = new Date().toISOString();
+    const row = {
+      userId,
+      email: email || null,
+      preferredUsername: preferredUsername || null,
+      displayName: preferredUsername || null,
+      avatarUrl: null,
+      profileVisibility: 'public',
+      createdAt: now,
+      lastSeenAt: now,
+    };
+
+    await docClient.send(
+      new PutCommand({
+        TableName: TABLE,
+        Item: row,
+        ConditionExpression: 'attribute_not_exists(userId)',
+      }),
+    );
+    console.log('users-create: created row for', userId);
+  } catch (err) {
+    if (err && err.name === 'ConditionalCheckFailedException') {
+      console.log('users-create: row already exists, skipping');
+    } else {
+      console.error('users-create: error writing row', err);
+    }
+  }
+
+  return event;
+};

--- a/lambda/users/users-edit/index.js
+++ b/lambda/users/users-edit/index.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.USERS_TABLE_NAME;
+const AVATARS_BUCKET = process.env.AVATARS_BUCKET_NAME || '';
+const CDN_HOST = 'cdn.xomware.com';
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+function getUserId(event) {
+  const claims =
+    event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims;
+  return claims && claims.sub ? claims.sub : null;
+}
+
+function isAllowedAvatarUrl(url) {
+  if (!url) return true; // null is allowed (clear avatar)
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return false;
+    if (u.hostname === CDN_HOST) return true;
+    // Also allow direct bucket origin (s3 virtual-hosted style)
+    if (AVATARS_BUCKET && u.hostname.startsWith(`${AVATARS_BUCKET}.s3`)) return true;
+    return false;
+  } catch (err) {
+    return false;
+  }
+}
+
+exports.handler = async (event) => {
+  const userId = getUserId(event);
+  if (!userId) return json(401, { error: 'unauthorized' });
+
+  let body;
+  try {
+    body = event && event.body ? JSON.parse(event.body) : {};
+  } catch (err) {
+    return json(400, { error: 'invalid_json' });
+  }
+
+  const updates = {};
+  const errors = [];
+
+  if (Object.prototype.hasOwnProperty.call(body, 'displayName')) {
+    const dn = body.displayName;
+    if (typeof dn !== 'string' || dn.length < 1 || dn.length > 50) {
+      errors.push('displayName must be 1-50 chars');
+    } else {
+      updates.displayName = dn;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'avatarUrl')) {
+    const av = body.avatarUrl;
+    if (av !== null && typeof av !== 'string') {
+      errors.push('avatarUrl must be string or null');
+    } else if (av && !isAllowedAvatarUrl(av)) {
+      errors.push('avatarUrl host not allowed');
+    } else {
+      updates.avatarUrl = av;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'profileVisibility')) {
+    const pv = body.profileVisibility;
+    if (pv !== 'public' && pv !== 'private') {
+      errors.push('profileVisibility must be public or private');
+    } else {
+      updates.profileVisibility = pv;
+    }
+  }
+
+  if (errors.length > 0) return json(400, { error: 'validation_failed', details: errors });
+  if (Object.keys(updates).length === 0) return json(400, { error: 'no_fields_to_update' });
+
+  const setExpr = [];
+  const exprAttrNames = {};
+  const exprAttrValues = {};
+  for (const [key, val] of Object.entries(updates)) {
+    setExpr.push(`#${key} = :${key}`);
+    exprAttrNames[`#${key}`] = key;
+    exprAttrValues[`:${key}`] = val;
+  }
+
+  try {
+    const { Attributes } = await docClient.send(
+      new UpdateCommand({
+        TableName: TABLE,
+        Key: { userId },
+        UpdateExpression: 'SET ' + setExpr.join(', '),
+        ExpressionAttributeNames: exprAttrNames,
+        ExpressionAttributeValues: exprAttrValues,
+        ConditionExpression: 'attribute_exists(userId)',
+        ReturnValues: 'ALL_NEW',
+      }),
+    );
+    return json(200, Attributes);
+  } catch (err) {
+    if (err && err.name === 'ConditionalCheckFailedException') {
+      return json(404, { error: 'user_not_found' });
+    }
+    console.error('users-edit error', err);
+    return json(500, { error: 'internal_error' });
+  }
+};

--- a/lambda/users/users-get-by-handle/index.js
+++ b/lambda/users/users-get-by-handle/index.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, QueryCommand } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.USERS_TABLE_NAME;
+const HANDLE_INDEX = 'handle-index';
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+exports.handler = async (event) => {
+  let body;
+  try {
+    body = event && event.body ? JSON.parse(event.body) : {};
+  } catch (err) {
+    return json(400, { error: 'invalid_json' });
+  }
+
+  const handle = body && typeof body.handle === 'string' ? body.handle.trim() : '';
+  if (!handle) return json(400, { error: 'handle_required' });
+
+  try {
+    const { Items } = await docClient.send(
+      new QueryCommand({
+        TableName: TABLE,
+        IndexName: HANDLE_INDEX,
+        KeyConditionExpression: 'preferredUsername = :h',
+        ExpressionAttributeValues: { ':h': handle },
+        Limit: 1,
+      }),
+    );
+
+    if (!Items || Items.length === 0) return json(404, { error: 'user_not_found' });
+
+    const row = Items[0];
+    return json(200, {
+      userId: row.userId,
+      preferredUsername: row.preferredUsername,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      profileVisibility: row.profileVisibility,
+    });
+  } catch (err) {
+    console.error('users-get-by-handle error', err);
+    return json(500, { error: 'internal_error' });
+  }
+};

--- a/lambda/users/users-me/index.js
+++ b/lambda/users/users-me/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.USERS_TABLE_NAME;
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+function getUserId(event) {
+  const claims =
+    event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims;
+  return claims && claims.sub ? claims.sub : null;
+}
+
+exports.handler = async (event) => {
+  const userId = getUserId(event);
+  if (!userId) return json(401, { error: 'unauthorized' });
+
+  try {
+    const { Item } = await docClient.send(
+      new GetCommand({ TableName: TABLE, Key: { userId } }),
+    );
+    if (!Item) return json(404, { error: 'user_not_found' });
+
+    // Fire-and-forget lastSeenAt update — don't block the response.
+    const now = new Date().toISOString();
+    docClient
+      .send(
+        new UpdateCommand({
+          TableName: TABLE,
+          Key: { userId },
+          UpdateExpression: 'SET lastSeenAt = :now',
+          ExpressionAttributeValues: { ':now': now },
+        }),
+      )
+      .catch((err) => console.error('users-me: lastSeenAt update failed', err));
+
+    return json(200, Item);
+  } catch (err) {
+    console.error('users-me error', err);
+    return json(500, { error: 'internal_error' });
+  }
+};

--- a/lambda/users/users-presign-avatar/index.js
+++ b/lambda/users/users-presign-avatar/index.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+const { randomUUID } = require('crypto');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const BUCKET = process.env.AVATARS_BUCKET_NAME;
+const CDN_BASE = process.env.AVATARS_CDN_URL || 'https://cdn.xomware.com';
+const KMS_KEY_ARN = process.env.AVATARS_KMS_KEY_ARN || '';
+const URL_TTL_SECONDS = 5 * 60;
+
+const s3 = new S3Client({ region });
+
+const allowedTypes = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+function getUserId(event) {
+  const claims =
+    event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims;
+  return claims && claims.sub ? claims.sub : null;
+}
+
+exports.handler = async (event) => {
+  const userId = getUserId(event);
+  if (!userId) return json(401, { error: 'unauthorized' });
+
+  let body;
+  try {
+    body = event && event.body ? JSON.parse(event.body) : {};
+  } catch (err) {
+    return json(400, { error: 'invalid_json' });
+  }
+
+  const contentType = body && body.contentType;
+  if (!allowedTypes[contentType]) {
+    return json(400, { error: 'unsupported_content_type', allowed: Object.keys(allowedTypes) });
+  }
+
+  const ext = allowedTypes[contentType];
+  const key = `avatars/${userId}/${randomUUID()}.${ext}`;
+
+  try {
+    const putParams = {
+      Bucket: BUCKET,
+      Key: key,
+      ContentType: contentType,
+      ServerSideEncryption: 'aws:kms',
+    };
+    if (KMS_KEY_ARN) putParams.SSEKMSKeyId = KMS_KEY_ARN;
+
+    const command = new PutObjectCommand(putParams);
+    const uploadUrl = await getSignedUrl(s3, command, { expiresIn: URL_TTL_SECONDS });
+    const finalUrl = `${CDN_BASE.replace(/\/$/, '')}/${key}`;
+
+    return json(200, { uploadUrl, finalUrl, key, contentType, expiresIn: URL_TTL_SECONDS });
+  } catch (err) {
+    console.error('users-presign-avatar error', err);
+    return json(500, { error: 'internal_error' });
+  }
+};

--- a/terraform/api_users.tf
+++ b/terraform/api_users.tf
@@ -1,0 +1,127 @@
+#**********************
+# Users service - REST API v1 via api-gateway-service v2.5.0
+# Hosted at api.xomware.com (formerly file-editor; migrated to editor-api).
+# Authorization: COGNITO_USER_POOLS using shared Xomware pool.
+#**********************
+
+# ACM cert for api.xomware.com — replaces the file-editor cert that just got
+# moved to editor-api.<domain>. file_editor_api.tf's aws_acm_certificate.api
+# resource still has TF resource name "api" but now provisions a cert for
+# editor-api.<domain>, so this REST API uses a separately named cert.
+
+resource "aws_acm_certificate" "users_api" {
+  domain_name       = "api.${local.domain_name}"
+  validation_method = "DNS"
+  tags              = local.standard_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "users_api_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.users_api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.aws_route53_zone.web_zone.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "users_api" {
+  certificate_arn         = aws_acm_certificate.users_api.arn
+  validation_record_fqdns = [for record in aws_route53_record.users_api_cert_validation : record.fqdn]
+}
+
+# --- API Gateway via shared module ---
+
+locals {
+  users_endpoints = [
+    {
+      name        = "me"
+      path_part   = "me"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.users["me"].invoke_arn
+    },
+    {
+      name        = "get-by-handle"
+      path_part   = "get-by-handle"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.users["get_by_handle"].invoke_arn
+    },
+    {
+      name        = "edit"
+      path_part   = "edit"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.users["edit"].invoke_arn
+    },
+    {
+      name        = "presign-avatar"
+      path_part   = "presign-avatar"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.users["presign_avatar"].invoke_arn
+    },
+  ]
+
+  users_allow_origins = join(",", [
+    "https://xomware.com",
+    "https://xn--xomapptit-g4a.xomware.com",
+    "https://xomappetit.xomware.com",
+    "http://localhost:3000",
+    "http://localhost:4200",
+  ])
+
+  users_allow_headers = [
+    "Authorization",
+    "Content-Type",
+    "X-Amz-Date",
+    "X-Amz-Security-Token",
+    "X-Api-Key",
+    "Origin",
+    "Accept",
+  ]
+}
+
+module "users_api" {
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.5.0"
+
+  app_name      = "${var.app_name}-users"
+  stage_name    = "prod"
+  authorization = "COGNITO_USER_POOLS"
+  cognito_user_pool_arns = [
+    aws_cognito_user_pool.xomware_users.arn,
+  ]
+  tags          = local.standard_tags
+  allow_headers = local.users_allow_headers
+  allow_origin  = local.users_allow_origins
+
+  domain_name     = "api.${local.domain_name}"
+  certificate_arn = aws_acm_certificate_validation.users_api.certificate_arn
+
+  services = {
+    users = {
+      path_prefix = "users"
+      endpoints   = local.users_endpoints
+    }
+  }
+}
+
+# Route53 alias for api.xomware.com -> users-service domain
+resource "aws_route53_record" "users_api" {
+  zone_id = data.aws_route53_zone.web_zone.zone_id
+  name    = "api.${local.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.users_api.domain_regional_domain_name
+    zone_id                = module.users_api.domain_regional_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/cdn_avatars.tf
+++ b/terraform/cdn_avatars.tf
@@ -1,0 +1,115 @@
+#**********************
+# Users service - CloudFront CDN for avatars
+# cdn.xomware.com -> xomware-avatars S3 bucket via OAC.
+# 1y immutable cache. Geo: var.us_canada_only. Shared CloudFront WAF.
+#**********************
+
+# ACM cert for cdn.xomware.com (CloudFront cert MUST be in us-east-1).
+# Provider default region is us-east-1, so this is fine without aliasing.
+resource "aws_acm_certificate" "cdn" {
+  domain_name       = "cdn.${local.domain_name}"
+  validation_method = "DNS"
+  tags              = local.standard_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cdn_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cdn.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.aws_route53_zone.web_zone.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "cdn" {
+  certificate_arn         = aws_acm_certificate.cdn.arn
+  validation_record_fqdns = [for record in aws_route53_record.cdn_cert_validation : record.fqdn]
+}
+
+# Origin Access Control — preferred over legacy OAI for KMS-encrypted buckets.
+resource "aws_cloudfront_origin_access_control" "avatars" {
+  name                              = "${var.app_name}-avatars-oac"
+  description                       = "OAC for xomware-avatars bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "avatars" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "xomware-avatars CDN"
+  default_root_object = ""
+  price_class         = "PriceClass_100"
+  http_version        = "http2"
+  web_acl_id          = module.waf_cloudfront.web_acl_arn
+  aliases             = ["cdn.${local.domain_name}"]
+
+  origin {
+    domain_name              = aws_s3_bucket.avatars.bucket_regional_domain_name
+    origin_id                = "s3-${aws_s3_bucket.avatars.id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.avatars.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-${aws_s3_bucket.avatars.id}"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    # 1y immutable cache. Avatar URLs include a UUID so cache busting is by URL.
+    min_ttl     = 0
+    default_ttl = 31536000
+    max_ttl     = 31536000
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cdn.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = var.us_canada_only ? "whitelist" : "none"
+      locations        = var.us_canada_only ? ["US", "CA"] : []
+    }
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-avatars-cdn"
+    "environment" = "shared"
+    "owner"       = "xomware"
+  })
+}
+
+resource "aws_route53_record" "cdn" {
+  zone_id = data.aws_route53_zone.web_zone.zone_id
+  name    = "cdn.${local.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.avatars.domain_name
+    zone_id                = aws_cloudfront_distribution.avatars.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -85,6 +85,13 @@ resource "aws_cognito_user_pool" "xomware_users" {
   # Self-service signup is implicitly enabled (allow_admin_create_user_only = false).
   # No custom attributes — profile data lives in DynamoDB (Phase 3).
 
+  # Phase 3: PostConfirmation Lambda trigger writes the user row to
+  # xomware-users on email-verified signup. Per AWS provider docs this is an
+  # in-place update (NOT replacement). See lambdas_users.tf for the Lambda.
+  lambda_config {
+    post_confirmation = aws_lambda_function.users["create"].arn
+  }
+
   tags = merge(local.standard_tags, {
     "environment" = "shared"
     "owner"       = "xomware"
@@ -94,6 +101,15 @@ resource "aws_cognito_user_pool" "xomware_users" {
   lifecycle {
     ignore_changes = [tags_all]
   }
+}
+
+# Allow Cognito to invoke the users-create PostConfirmation lambda.
+resource "aws_lambda_permission" "users_create_cognito" {
+  statement_id  = "AllowCognitoInvokeUsersCreate"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.users["create"].function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.xomware_users.arn
 }
 
 # Hosted UI domain (Amazon-hosted prefix).

--- a/terraform/dynamodb_users.tf
+++ b/terraform/dynamodb_users.tf
@@ -1,0 +1,43 @@
+#**********************
+# Users service - DynamoDB
+# Single table: xomware-users
+# PK: userId (Cognito sub)
+# GSI: handle-index (preferredUsername -> userId)
+#**********************
+
+resource "aws_dynamodb_table" "users" {
+  name         = "${var.app_name}-users"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "userId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.web_app.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  attribute {
+    name = "preferredUsername"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "handle-index"
+    hash_key        = "preferredUsername"
+    projection_type = "ALL"
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-users"
+    "environment" = "shared"
+    "owner"       = "xomware"
+  })
+}

--- a/terraform/file_editor_api.tf
+++ b/terraform/file_editor_api.tf
@@ -274,10 +274,14 @@ resource "aws_lambda_permission" "file_editor_apigw" {
   source_arn    = "${aws_apigatewayv2_api.file_editor.execution_arn}/*/*"
 }
 
-# --- Custom Domain (api.xomware.com) ---
+# --- Custom Domain (editor-api.xomware.com) ---
+# Migrated from api.xomware.com -> editor-api.xomware.com so the
+# api.xomware.com hostname can host the new shared users service
+# (see api_users.tf). Internal-only Command Center traffic; brief
+# unavailability during DNS+CF propagation is acceptable.
 
 resource "aws_acm_certificate" "api" {
-  domain_name       = "api.${local.domain_name}"
+  domain_name       = "editor-api.${local.domain_name}"
   validation_method = "DNS"
   tags              = local.standard_tags
 
@@ -308,7 +312,7 @@ resource "aws_acm_certificate_validation" "api" {
 }
 
 resource "aws_apigatewayv2_domain_name" "file_editor" {
-  domain_name = "api.${local.domain_name}"
+  domain_name = "editor-api.${local.domain_name}"
 
   domain_name_configuration {
     certificate_arn = aws_acm_certificate_validation.api.certificate_arn
@@ -327,7 +331,7 @@ resource "aws_apigatewayv2_api_mapping" "file_editor" {
 
 resource "aws_route53_record" "api" {
   zone_id = data.aws_route53_zone.web_zone.zone_id
-  name    = "api.${local.domain_name}"
+  name    = "editor-api.${local.domain_name}"
   type    = "A"
 
   alias {
@@ -340,7 +344,7 @@ resource "aws_route53_record" "api" {
 # --- Outputs ---
 
 output "file_editor_api_url" {
-  value       = "https://api.${local.domain_name}/config"
+  value       = "https://editor-api.${local.domain_name}/config"
   description = "File Editor API base URL"
 }
 

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -65,7 +65,10 @@ resource "aws_kms_key" "web_app" {
           "Resource" : "*",
           "Condition" : {
             "StringEquals" : {
-              "aws:SourceArn" : module.web.cloudfront_distribution_arn
+              "aws:SourceArn" : [
+                module.web.cloudfront_distribution_arn,
+                aws_cloudfront_distribution.avatars.arn,
+              ]
             }
           }
         }

--- a/terraform/lambdas_users.tf
+++ b/terraform/lambdas_users.tf
@@ -1,0 +1,169 @@
+#**********************
+# Users service - Lambda functions
+# 5 Node.js 20.x handlers + bundled IAM role.
+# Source: ../lambda/users/<function-name>/index.js
+# Bundled via archive_file (no CI build step).
+#**********************
+
+locals {
+  users_lambdas = {
+    create = {
+      name        = "users-create"
+      description = "Cognito PostConfirmation: write user row"
+      source_dir  = "${path.module}/../lambda/users/users-create"
+      timeout     = 10
+      memory      = 256
+    }
+    me = {
+      name        = "users-me"
+      description = "GET /users/me - return authed user row"
+      source_dir  = "${path.module}/../lambda/users/users-me"
+      timeout     = 10
+      memory      = 256
+    }
+    get_by_handle = {
+      name        = "users-get-by-handle"
+      description = "POST /users/get-by-handle - GSI lookup"
+      source_dir  = "${path.module}/../lambda/users/users-get-by-handle"
+      timeout     = 10
+      memory      = 256
+    }
+    edit = {
+      name        = "users-edit"
+      description = "POST /users/edit - update displayName/avatarUrl/visibility"
+      source_dir  = "${path.module}/../lambda/users/users-edit"
+      timeout     = 10
+      memory      = 256
+    }
+    presign_avatar = {
+      name        = "users-presign-avatar"
+      description = "POST /users/presign-avatar - issue PUT presigned URL"
+      source_dir  = "${path.module}/../lambda/users/users-presign-avatar"
+      timeout     = 10
+      memory      = 256
+    }
+  }
+
+  users_lambda_env = {
+    USERS_TABLE_NAME    = aws_dynamodb_table.users.id
+    AVATARS_BUCKET_NAME = aws_s3_bucket.avatars.id
+    AVATARS_CDN_URL     = "https://cdn.${local.domain_name}"
+    AVATARS_KMS_KEY_ARN = aws_kms_alias.web_app.target_key_arn
+  }
+}
+
+# --- IAM role ---
+
+data "aws_iam_policy_document" "users_lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "users_lambda" {
+  name               = "${var.app_name}-users-lambdas"
+  assume_role_policy = data.aws_iam_policy_document.users_lambda_assume.json
+  tags               = merge(local.standard_tags, { "name" = "${var.app_name}-users-lambdas" })
+}
+
+resource "aws_iam_role_policy_attachment" "users_lambda_basic" {
+  role       = aws_iam_role.users_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "users_lambda" {
+  # DynamoDB on users table + GSI
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+      "dynamodb:DescribeTable",
+    ]
+    resources = [
+      aws_dynamodb_table.users.arn,
+      "${aws_dynamodb_table.users.arn}/index/*",
+    ]
+  }
+
+  # S3 - presigned PUT signing requires the signer's role to have PutObject
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+    resources = ["${aws_s3_bucket.avatars.arn}/avatars/*"]
+  }
+
+  # KMS - encrypt/decrypt for avatars bucket + DynamoDB encryption
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+    resources = [aws_kms_alias.web_app.target_key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "users_lambda" {
+  name   = "${var.app_name}-users-lambdas-policy"
+  role   = aws_iam_role.users_lambda.id
+  policy = data.aws_iam_policy_document.users_lambda.json
+}
+
+# --- Lambda packaging ---
+
+data "archive_file" "users" {
+  for_each    = local.users_lambdas
+  type        = "zip"
+  source_dir  = each.value.source_dir
+  output_path = "${path.module}/../lambda/users/${each.value.name}.zip"
+}
+
+resource "aws_lambda_function" "users" {
+  for_each = local.users_lambdas
+
+  function_name    = "${var.app_name}-${each.value.name}"
+  description      = each.value.description
+  role             = aws_iam_role.users_lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs20.x"
+  timeout          = each.value.timeout
+  memory_size      = each.value.memory
+  filename         = data.archive_file.users[each.key].output_path
+  source_code_hash = data.archive_file.users[each.key].output_base64sha256
+
+  environment {
+    variables = local.users_lambda_env
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-${each.value.name}"
+    "environment" = "shared"
+    "owner"       = "xomware"
+    "lambda_type" = "users"
+  })
+}
+
+# Convenience aliases for resources referenced elsewhere
+resource "aws_lambda_function_event_invoke_config" "users_create" {
+  function_name                = aws_lambda_function.users["create"].function_name
+  maximum_event_age_in_seconds = 60
+  maximum_retry_attempts       = 0
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -30,3 +30,30 @@ output "cognito_client_xomappetit_id" {
   description = "Cognito App Client ID for xomappetit"
   value       = aws_cognito_user_pool_client.xomappetit.id
 }
+
+# Phase 3 - users service + avatars + file-editor migration
+
+output "users_api_url" {
+  description = "Shared Xomware users service base URL"
+  value       = "https://api.${local.domain_name}"
+}
+
+output "avatars_bucket_name" {
+  description = "S3 bucket name for shared user avatars"
+  value       = aws_s3_bucket.avatars.id
+}
+
+output "avatars_cdn_url" {
+  description = "CloudFront CDN base URL for shared user avatars"
+  value       = "https://cdn.${local.domain_name}"
+}
+
+output "file_editor_api_url_export" {
+  description = "File Editor API base URL (Command Center backend)"
+  value       = "https://editor-api.${local.domain_name}"
+}
+
+output "users_dynamodb_table" {
+  description = "DynamoDB table for the users service"
+  value       = aws_dynamodb_table.users.id
+}

--- a/terraform/s3_avatars.tf
+++ b/terraform/s3_avatars.tf
@@ -1,0 +1,100 @@
+#**********************
+# Users service - Avatars S3 bucket
+# Public access blocked, KMS encryption, versioning enabled.
+# CORS PUT from xomware web frontends + localhost.
+# Lifecycle: noncurrent versions deleted at 90d.
+#**********************
+
+resource "aws_s3_bucket" "avatars" {
+  bucket = "${var.app_name}-avatars"
+
+  force_destroy = false
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-avatars"
+    "environment" = "shared"
+    "owner"       = "xomware"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_alias.web_app.target_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "avatars" {
+  bucket                  = aws_s3_bucket.avatars.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_cors_configuration" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = [
+      "https://xomware.com",
+      "https://xn--xomapptit-g4a.xomware.com",
+      "https://xomappetit.xomware.com",
+      "http://localhost:3000",
+      "http://localhost:4200",
+    ]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  rule {
+    id     = "expire-noncurrent"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+# Bucket policy: allow CloudFront (avatars distribution) to read via OAC.
+resource "aws_s3_bucket_policy" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipalRead"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.avatars.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.avatars.arn
+          }
+        }
+      },
+    ]
+  })
+}

--- a/terraform/users_ssm.tf
+++ b/terraform/users_ssm.tf
@@ -1,0 +1,40 @@
+#**********************
+# SSM exports - users service + avatars + file-editor migration
+# Consumed by xomware-frontend (Command Center, profile page).
+#**********************
+
+resource "aws_ssm_parameter" "users_api_url" {
+  name        = "/xomware/shared/users-api/url"
+  description = "Shared Xomware users service base URL"
+  type        = "String"
+  value       = "https://api.${local.domain_name}"
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "avatars_bucket_name" {
+  name        = "/xomware/shared/avatars/bucket-name"
+  description = "S3 bucket name for shared user avatars"
+  type        = "String"
+  value       = aws_s3_bucket.avatars.id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "avatars_cdn_url" {
+  name        = "/xomware/shared/avatars/cdn-url"
+  description = "CloudFront CDN base URL for shared user avatars"
+  type        = "String"
+  value       = "https://cdn.${local.domain_name}"
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "file_editor_api_url" {
+  name        = "/xomware/shared/file-editor-api/url"
+  description = "File Editor API base URL (Command Center backend)"
+  type        = "String"
+  value       = "https://editor-api.${local.domain_name}"
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}


### PR DESCRIPTION
## Summary

Two coordinated work-streams in one PR:

### A) file-editor migration (`api.xomware.com` -> `editor-api.xomware.com`)
- ACM cert subject: `api.xomware.com` -> `editor-api.xomware.com`
- APIGW v2 `aws_apigatewayv2_domain_name.file_editor` -> `editor-api.xomware.com`
- Route53 record `aws_route53_record.api` now points `editor-api.xomware.com` at the same v2 domain regional target
- Lambda code, API itself, and routes (`/config/*`, `/infra/*`, `/status/*`) unchanged
- Frees `api.xomware.com` for the users service

### B) users service (Phase 3 of auth epic)
- `xomware-users` DynamoDB table: PK=`userId` (Cognito sub), GSI `handle-index` on `preferredUsername`, KMS, PITR
- `xomware-avatars` S3 bucket: public access blocked, KMS, versioned, CORS PUT from frontends + localhost, lifecycle 90d noncurrent
- `cdn.xomware.com` CloudFront distribution via OAC, shared CloudFront WAF, geo `var.us_canada_only`, 1y immutable
- KMS key policy extended to allow CloudFront `kms:Decrypt` for the avatars distribution
- `api.xomware.com` REST API v1 via `api-gateway-service` v2.5.0 with `COGNITO_USER_POOLS` auth against the shared pool
- 4 API endpoints under `/users`: `me`, `get-by-handle`, `edit`, `presign-avatar` (all POST)
- 5 Node.js 20.x lambdas: `users-create` (Cognito PostConfirmation trigger) + 4 API handlers
- Cognito pool: PostConfirmation trigger added (in-place update, NOT replacement)
- SSM: `/xomware/shared/users-api/url`, `/xomware/shared/avatars/{bucket-name,cdn-url}`, `/xomware/shared/file-editor-api/url`
- Outputs mirror SSM exports

## Plan review checklist

Before merging, verify in CI plan output:

- [ ] **Cognito pool change is `update in-place` (~), NOT replacement (-/+)** — pool has `deletion_protection = ACTIVE` and live users
- [ ] file-editor `aws_acm_certificate.api` shows replacement (cert subject changed) — `create_before_destroy` on the cert
- [ ] `aws_apigatewayv2_domain_name.file_editor` shows replacement at `editor-api.xomware.com`
- [ ] `aws_route53_record.api` updates to point at the v2 domain at `editor-api.xomware.com`
- [ ] New `aws_acm_certificate.users_api` for `api.xomware.com` is created (no naming conflict with the renamed file-editor cert because TF resource names differ)
- [ ] New `aws_route53_record.users_api` (zone record `api.xomware.com`) created pointing at the new REST API regional domain
- [ ] No unexpected destroys outside of file-editor migration

## Test plan

- [ ] Verify CI `terraform plan` is clean and matches the checklist above
- [ ] Apply via merge — file-editor unavailable for ~5-10 min during DNS propagation (acceptable, internal-only)
- [ ] Verify `https://editor-api.xomware.com/config/files` is reachable post-deploy
- [ ] Verify `https://api.xomware.com/users/me` returns 401 unauthenticated, 200 with valid JWT
- [ ] Verify Cognito sign-up triggers users-create lambda; check `xomware-users` table for new row
- [ ] Verify `https://cdn.xomware.com/<path>` returns 403 for missing keys (bucket policy works)

Companion PRs:
- xomware-frontend: file-editor URL update (small)
- frontend Phase 3 PRs (#8, #106) ride along