### PR TITLE
fix: allow_overwrite on users_api cert validation record

### DIFF
--- a/terraform/api_users.tf
+++ b/terraform/api_users.tf
@@ -28,11 +28,16 @@ resource "aws_route53_record" "users_api_cert_validation" {
     }
   }
 
-  zone_id = data.aws_route53_zone.web_zone.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  records = [each.value.record]
-  ttl     = 60
+  # The old file-editor cert (renamed to editor-api in this same apply) and
+  # the new users_api cert both use api.xomware.com → identical _HASH.api
+  # validation CNAME. Allow overwrite so the new record replaces the old
+  # one cleanly during the cutover instead of erroring on "already exists".
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.web_zone.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
 }
 
 resource "aws_acm_certificate_validation" "users_api" {


### PR DESCRIPTION
Phase 3 apply (PR #23) hit InvalidChangeBatch on the cert validation CNAME for api.xomware.com. The old file-editor cert and the new users_api cert both validate against the same domain → same hash → same CNAME record name. Apply tried to create new before destroy completed.

allow_overwrite makes the new record replace the old one in-place.