### PR TITLE
fix(cognito): step 1/2 — flip deletion_protection to INACTIVE

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -18,19 +18,14 @@
 resource "aws_cognito_user_pool" "xomware_users" {
   name = "xomware-users"
 
-  # Opaque UUID Username supplied at signup; sign-in via email alias only.
-  # Note on preferred_username: NOT an alias attribute and NOT in the
-  # required schema. Cognito treats alias attributes as "claimable on
-  # confirmed accounts only" (rejects them at SignUp), but ALSO requires
-  # any schema-marked-required attribute at SignUp — a catch-22 if you
-  # mark preferred_username both required AND alias. Solution: handles
-  # live exclusively in DynamoDB (xomware-users.preferredUsername),
-  # uniqueness enforced by app logic via the handle-index GSI.
-  alias_attributes         = ["email"]
+  # Opaque UUID Username supplied at signup; sign-in via aliases.
+  alias_attributes         = ["email", "preferred_username"]
   auto_verified_attributes = ["email"]
 
-  # INACTIVE temporarily to allow this schema fix (pool replacement).
-  # Flip back to ACTIVE in a follow-up PR after the new pool is verified.
+  # Step 1 of a two-PR fix: flip deletion_protection to INACTIVE first
+  # (in-place update). Step 2 (follow-up PR) does the schema/alias removal
+  # which forces pool replacement — needs INACTIVE in AWS state to succeed.
+  # Re-enable after the schema fix lands and pool is verified.
   deletion_protection = "INACTIVE"
 
   user_pool_tier = "ESSENTIALS"
@@ -63,8 +58,8 @@ resource "aws_cognito_user_pool" "xomware_users" {
     email_sending_account = "COGNITO_DEFAULT"
   }
 
-  # Required schema attributes. Only email is enforced at the Cognito layer.
-  # Handle (preferredUsername) lives in DynamoDB — see comment on alias_attributes.
+  # Required schema attributes. Both required + mutable.
+  # preferred_username uniqueness is enforced via alias_attributes above.
   schema {
     name                     = "email"
     attribute_data_type      = "String"
@@ -75,6 +70,19 @@ resource "aws_cognito_user_pool" "xomware_users" {
     string_attribute_constraints {
       min_length = 1
       max_length = 256
+    }
+  }
+
+  schema {
+    name                     = "preferred_username"
+    attribute_data_type      = "String"
+    required                 = true
+    mutable                  = true
+    developer_only_attribute = false
+
+    string_attribute_constraints {
+      min_length = 3
+      max_length = 20
     }
   }
 


### PR DESCRIPTION
PR #27's apply failed: replacement-forced changes can't delete a pool with deletion_protection=ACTIVE. Need to disable it first via in-place update, then a follow-up PR does the schema replacement.

Plan: 1 in-place change (deletion_protection: ACTIVE → INACTIVE).