### PR TITLE
fix(api): bump module to v2.6.0 — CORS VTL fix

### DIFF
--- a/terraform/api_users.tf
+++ b/terraform/api_users.tf
@@ -95,7 +95,7 @@ locals {
 }
 
 module "users_api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.5.0"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.6.0"
 
   app_name      = "${var.app_name}-users"
   stage_name    = "prod"


### PR DESCRIPTION
Multi-origin CORS preflight was returning 500 due to malformed VTL in v2.5.0 (multiple unclosed #if blocks). v2.6.0 fixes it. xomware.com → api.xomware.com calls will work after this applies.