### PR TITLE
Phase 4 (infra): Google federation + PreSignUp link trigger

### DIFF
--- a/lambda/users/users-presignup-link/index.js
+++ b/lambda/users/users-presignup-link/index.js
@@ -1,0 +1,141 @@
+'use strict';
+
+// Cognito PreSignUp trigger.
+//
+// Fires before a new user is created. We only act on
+// `PreSignUp_ExternalProvider` (federated sign-up via Google etc.).
+// If a CONFIRMED native Cognito user already exists with the same
+// email, we link the federated identity to that existing user so
+// they end up as a single account with two providers — instead of
+// two separate Cognito users sharing an email.
+//
+// Other trigger sources (PreSignUp_SignUp, PreSignUp_AdminCreateUser)
+// pass through untouched.
+//
+// Env:
+//   USER_POOL_ID_SSM_PARAM — required, SSM param name holding the pool id.
+//     We read SSM (not TF env) to avoid a TF dependency cycle: the pool's
+//     lambda_config references this Lambda's ARN, so the Lambda can't
+//     reference the pool's id back through env without cycling.
+
+const {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  AdminLinkProviderForUserCommand,
+} = require('@aws-sdk/client-cognito-identity-provider');
+const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const POOL_ID_SSM_PARAM = process.env.USER_POOL_ID_SSM_PARAM;
+
+const cognito = new CognitoIdentityProviderClient({ region });
+const ssm = new SSMClient({ region });
+
+let cachedPoolId = null;
+
+async function getUserPoolId() {
+  if (cachedPoolId) return cachedPoolId;
+  if (!POOL_ID_SSM_PARAM) {
+    throw new Error('USER_POOL_ID_SSM_PARAM env var is not set');
+  }
+  const res = await ssm.send(
+    new GetParameterCommand({ Name: POOL_ID_SSM_PARAM, WithDecryption: false }),
+  );
+  cachedPoolId = res.Parameter && res.Parameter.Value;
+  if (!cachedPoolId) throw new Error(`SSM param ${POOL_ID_SSM_PARAM} has no value`);
+  return cachedPoolId;
+}
+
+exports.handler = async (event) => {
+  const triggerSource = event && event.triggerSource;
+
+  // Only handle external-provider sign-ups. Native sign-ups don't
+  // need linking (PostConfirmation handles the DDB row).
+  if (triggerSource !== 'PreSignUp_ExternalProvider') {
+    return event;
+  }
+
+  try {
+    const userPoolId = await getUserPoolId();
+
+    const attrs = (event.request && event.request.userAttributes) || {};
+    const email = attrs.email;
+    if (!email) {
+      console.warn('users-presignup-link: federated user has no email; skipping');
+      return event;
+    }
+
+    // event.userName for ExternalProvider looks like `Google_<sub>`.
+    // Split into provider name + provider attribute value (the Google sub).
+    const incomingUserName = event.userName || '';
+    const sepIdx = incomingUserName.indexOf('_');
+    if (sepIdx <= 0) {
+      console.warn(
+        'users-presignup-link: unexpected userName shape, skipping',
+        incomingUserName,
+      );
+      return event;
+    }
+    const providerName = incomingUserName.substring(0, sepIdx); // "Google"
+    const providerUserId = incomingUserName.substring(sepIdx + 1); // Google sub
+
+    // Look up any existing user(s) with this email.
+    const list = await cognito.send(
+      new ListUsersCommand({
+        UserPoolId: userPoolId,
+        Filter: `email = "${email}"`,
+        Limit: 5,
+      }),
+    );
+
+    const candidates = list.Users || [];
+
+    // Find a native (non-federated) CONFIRMED user. Federated users have
+    // a userName prefixed with the provider name (e.g. "Google_..."); skip
+    // those — they're already federated identities, not the native account
+    // we want to link to.
+    const native = candidates.find((u) => {
+      if (u.UserStatus !== 'CONFIRMED') return false;
+      const uname = u.Username || '';
+      return !uname.startsWith('Google_') && !uname.startsWith('Facebook_');
+    });
+
+    if (!native) {
+      // No native user to link to. Let signup proceed as a brand-new
+      // federated account; PostConfirmation will create the DDB row.
+      console.log('users-presignup-link: no native user for', email, '— passing through');
+      return event;
+    }
+
+    await cognito.send(
+      new AdminLinkProviderForUserCommand({
+        UserPoolId: userPoolId,
+        DestinationUser: {
+          ProviderName: 'Cognito',
+          ProviderAttributeValue: native.Username,
+        },
+        SourceUser: {
+          ProviderName: providerName,
+          ProviderAttributeName: 'Cognito_Subject',
+          ProviderAttributeValue: providerUserId,
+        },
+      }),
+    );
+
+    console.log(
+      'users-presignup-link: linked',
+      providerName,
+      'identity to native user',
+      native.Username,
+      'for',
+      email,
+    );
+  } catch (err) {
+    // Never throw — throwing fails the sign-up entirely. Log and let the
+    // user proceed; worst case they end up with two accounts and we can
+    // reconcile manually.
+    console.error('users-presignup-link: error', err);
+  }
+
+  return event;
+};

--- a/scripts/setup-google-oauth-ssm.sh
+++ b/scripts/setup-google-oauth-ssm.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Write the Google OAuth client credentials to SSM so the Phase 4 Terraform
+# (cognito_google_idp.tf) can read them. Run this ONCE, locally, with AWS
+# credentials that have ssm:PutParameter on /xomware/shared/google-oauth/*.
+#
+# Manual prereq:
+#   1. Create an OAuth 2.0 Client in Google Cloud Console
+#      (APIs & Services -> Credentials -> Create Credentials ->
+#      OAuth client ID, Application type "Web").
+#   2. Authorized redirect URIs:
+#        https://xomware-auth.auth.us-east-1.amazoncognito.com/oauth2/idpresponse
+#   3. Authorized JavaScript origins:
+#        https://xomware.com
+#        https://xn--xomapptit-g4a.xomware.com
+#        https://xomappetit.xomware.com
+#   4. Run this script and paste the values when prompted.
+#
+# After this completes, terraform apply will read the params via
+# data.aws_ssm_parameter and provision the Google IdP on the pool.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+PARAM_ID="/xomware/shared/google-oauth/client-id"
+PARAM_SECRET="/xomware/shared/google-oauth/client-secret"
+
+echo "Writing Google OAuth credentials to SSM in region: ${REGION}"
+echo
+
+# Sanity-check creds before prompting for secrets.
+if ! aws sts get-caller-identity --region "${REGION}" >/dev/null 2>&1; then
+  echo "ERROR: aws sts get-caller-identity failed. Check AWS credentials." >&2
+  exit 1
+fi
+
+read -r -p "Google OAuth client ID: " CLIENT_ID
+if [[ -z "${CLIENT_ID}" ]]; then
+  echo "ERROR: client ID cannot be empty." >&2
+  exit 1
+fi
+
+# -s suppresses echo so the secret never lands in scrollback.
+read -r -s -p "Google OAuth client secret: " CLIENT_SECRET
+echo
+if [[ -z "${CLIENT_SECRET}" ]]; then
+  echo "ERROR: client secret cannot be empty." >&2
+  exit 1
+fi
+
+echo
+echo "Writing ${PARAM_ID} (String)..."
+aws ssm put-parameter \
+  --region "${REGION}" \
+  --name "${PARAM_ID}" \
+  --type "String" \
+  --value "${CLIENT_ID}" \
+  --overwrite \
+  --tags 'Key=app,Value=xomware' 'Key=purpose,Value=google-oauth' \
+  >/dev/null
+
+echo "Writing ${PARAM_SECRET} (SecureString)..."
+aws ssm put-parameter \
+  --region "${REGION}" \
+  --name "${PARAM_SECRET}" \
+  --type "SecureString" \
+  --value "${CLIENT_SECRET}" \
+  --overwrite \
+  --tags 'Key=app,Value=xomware' 'Key=purpose,Value=google-oauth' \
+  >/dev/null
+
+# Tags only apply on first put — silently no-op on update. That's fine.
+unset CLIENT_SECRET
+
+echo
+echo "Verifying read-back..."
+aws ssm get-parameter \
+  --region "${REGION}" \
+  --name "${PARAM_ID}" \
+  --query 'Parameter.Name' \
+  --output text
+aws ssm get-parameter \
+  --region "${REGION}" \
+  --name "${PARAM_SECRET}" \
+  --with-decryption \
+  --query 'Parameter.Name' \
+  --output text
+
+echo
+echo "Done. You can now run 'terraform apply' on this branch."
+echo "Next: merge xomware-infrastructure#33, then xomware-frontend#112,"
+echo "      then xomappetit-frontend#13."

--- a/scripts/setup-google-oauth-ssm.sh
+++ b/scripts/setup-google-oauth-ssm.sh
@@ -48,28 +48,34 @@ if [[ -z "${CLIENT_SECRET}" ]]; then
   exit 1
 fi
 
+# SSM put-parameter rejects --tags and --overwrite together. Write the
+# value first (idempotent via --overwrite), then attach tags separately
+# (also idempotent via add-tags-to-resource).
+
+put_param() {
+  local name="$1" type="$2" value="$3"
+  aws ssm put-parameter \
+    --region "${REGION}" \
+    --name "${name}" \
+    --type "${type}" \
+    --value "${value}" \
+    --overwrite \
+    >/dev/null
+  aws ssm add-tags-to-resource \
+    --region "${REGION}" \
+    --resource-type "Parameter" \
+    --resource-id "${name}" \
+    --tags 'Key=app,Value=xomware' 'Key=purpose,Value=google-oauth' \
+    >/dev/null
+}
+
 echo
 echo "Writing ${PARAM_ID} (String)..."
-aws ssm put-parameter \
-  --region "${REGION}" \
-  --name "${PARAM_ID}" \
-  --type "String" \
-  --value "${CLIENT_ID}" \
-  --overwrite \
-  --tags 'Key=app,Value=xomware' 'Key=purpose,Value=google-oauth' \
-  >/dev/null
+put_param "${PARAM_ID}" "String" "${CLIENT_ID}"
 
 echo "Writing ${PARAM_SECRET} (SecureString)..."
-aws ssm put-parameter \
-  --region "${REGION}" \
-  --name "${PARAM_SECRET}" \
-  --type "SecureString" \
-  --value "${CLIENT_SECRET}" \
-  --overwrite \
-  --tags 'Key=app,Value=xomware' 'Key=purpose,Value=google-oauth' \
-  >/dev/null
+put_param "${PARAM_SECRET}" "SecureString" "${CLIENT_SECRET}"
 
-# Tags only apply on first put — silently no-op on update. That's fine.
 unset CLIENT_SECRET
 
 echo

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -117,11 +117,16 @@ resource "aws_cognito_user_pool" "xomware_users" {
   # xomware-users on email-verified signup. Per AWS provider docs this is an
   # in-place update (NOT replacement). See lambdas_users.tf for the Lambda.
   #
+  # Phase 4: PreSignUp Lambda trigger auto-links federated (Google) identities
+  # to existing native Cognito users when emails match — prevents duplicate
+  # accounts on first Google sign-in for an existing user.
+  #
   # Phase 5: PostAuthentication trigger writes a `signin` event to
   # xomware-events for the /admin portal audit log.
   lambda_config {
-    post_confirmation    = aws_lambda_function.users["create"].arn
-    post_authentication  = aws_lambda_function.auth_track.arn
+    post_confirmation   = aws_lambda_function.users["create"].arn
+    pre_sign_up         = aws_lambda_function.users["presignup_link"].arn
+    post_authentication = aws_lambda_function.auth_track.arn
   }
 
   tags = merge(local.standard_tags, {
@@ -140,6 +145,15 @@ resource "aws_lambda_permission" "users_create_cognito" {
   statement_id  = "AllowCognitoInvokeUsersCreate"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.users["create"].function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.xomware_users.arn
+}
+
+# Allow Cognito to invoke the users-presignup-link PreSignUp lambda.
+resource "aws_lambda_permission" "users_presignup_link_cognito" {
+  statement_id  = "AllowCognitoInvokeUsersPreSignupLink"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.users["presignup_link"].function_name
   principal     = "cognito-idp.amazonaws.com"
   source_arn    = aws_cognito_user_pool.xomware_users.arn
 }
@@ -189,7 +203,11 @@ resource "aws_cognito_user_pool_client" "xomware_com" {
     "http://localhost:4200",
   ]
 
-  supported_identity_providers = ["COGNITO"]
+  # Google added in Phase 4. The Google IdP must exist before this client
+  # can list it; explicit depends_on guarantees ordering.
+  supported_identity_providers = ["COGNITO", "Google"]
+
+  depends_on = [aws_cognito_identity_provider.google]
 
   prevent_user_existence_errors = "ENABLED"
   enable_token_revocation       = true
@@ -232,7 +250,10 @@ resource "aws_cognito_user_pool_client" "xomappetit" {
     "http://localhost:3000",
   ]
 
-  supported_identity_providers = ["COGNITO"]
+  # Google added in Phase 4. See xomware_com client comment.
+  supported_identity_providers = ["COGNITO", "Google"]
+
+  depends_on = [aws_cognito_identity_provider.google]
 
   prevent_user_existence_errors = "ENABLED"
   enable_token_revocation       = true

--- a/terraform/cognito_google_idp.tf
+++ b/terraform/cognito_google_idp.tf
@@ -1,0 +1,61 @@
+# -------------------------------------------------------------------
+# Google Identity Provider for the shared Xomware Cognito User Pool.
+#
+# Phase 4 of the auth epic. Federates Google sign-in for all Xomware
+# apps. The PreSignUp Lambda trigger (see lambdas_users.tf
+# `presignup_link`) auto-links a federating Google identity to an
+# existing local Cognito user when emails match — preventing
+# duplicate accounts.
+#
+# Manual prereq (Dom):
+#   1. Create an OAuth 2.0 Client in Google Cloud Console
+#      (APIs & Services -> Credentials -> Create Credentials ->
+#      OAuth client ID, Application type "Web").
+#   2. Authorized redirect URIs:
+#        https://xomware-auth.auth.us-east-1.amazoncognito.com/oauth2/idpresponse
+#   3. Authorized JavaScript origins:
+#        https://xomware.com
+#        https://xn--xomapptit-g4a.xomware.com
+#        https://xomappetit.xomware.com
+#   4. Save, then write the credentials to SSM:
+#        /xomware/shared/google-oauth/client-id     (String)
+#        /xomware/shared/google-oauth/client-secret (SecureString)
+#
+# Terraform reads those SSM params via the data sources below — apply
+# will FAIL until both params exist. That's intentional: it stops a
+# half-configured IdP from being attached to the live pool.
+# -------------------------------------------------------------------
+
+data "aws_ssm_parameter" "google_oauth_client_id" {
+  name            = "/xomware/shared/google-oauth/client-id"
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "google_oauth_client_secret" {
+  name            = "/xomware/shared/google-oauth/client-secret"
+  with_decryption = true
+}
+
+resource "aws_cognito_identity_provider" "google" {
+  user_pool_id  = aws_cognito_user_pool.xomware_users.id
+  provider_name = "Google"
+  provider_type = "Google"
+
+  provider_details = {
+    client_id        = data.aws_ssm_parameter.google_oauth_client_id.value
+    client_secret    = data.aws_ssm_parameter.google_oauth_client_secret.value
+    authorize_scopes = "profile email openid"
+  }
+
+  # Map Google claims -> Cognito user pool attributes.
+  # `email` is the critical one: the PreSignUp link trigger uses it
+  # to find a matching local user before federation creates a new row.
+  attribute_mapping = {
+    email       = "email"
+    name        = "name"
+    given_name  = "given_name"
+    family_name = "family_name"
+    picture     = "picture"
+    username    = "sub"
+  }
+}

--- a/terraform/cognito_google_idp.tf
+++ b/terraform/cognito_google_idp.tf
@@ -17,7 +17,9 @@
 #        https://xomware.com
 #        https://xn--xomapptit-g4a.xomware.com
 #        https://xomappetit.xomware.com
-#   4. Save, then write the credentials to SSM:
+#   4. Save, then write the credentials to SSM. Easiest path:
+#        ./scripts/setup-google-oauth-ssm.sh
+#      Or by hand:
 #        /xomware/shared/google-oauth/client-id     (String)
 #        /xomware/shared/google-oauth/client-secret (SecureString)
 #

--- a/terraform/lambdas_users.tf
+++ b/terraform/lambdas_users.tf
@@ -42,15 +42,28 @@ locals {
       timeout     = 10
       memory      = 256
     }
+    presignup_link = {
+      name        = "users-presignup-link"
+      description = "Cognito PreSignUp: link federated (Google) identity to existing native user when emails match"
+      source_dir  = "${path.module}/../lambda/users/users-presignup-link"
+      timeout     = 10
+      memory      = 256
+    }
   }
 
   users_lambda_env = {
-    USERS_TABLE_NAME       = aws_dynamodb_table.users.id
-    AVATARS_BUCKET_NAME    = aws_s3_bucket.avatars.id
-    AVATARS_CDN_URL        = "https://cdn.${local.domain_name}"
-    AVATARS_KMS_KEY_ARN    = aws_kms_alias.web_app.target_key_arn
-    EVENTS_TABLE_NAME      = aws_dynamodb_table.events.id
-    EVENTS_RETENTION_DAYS  = tostring(var.events_retention_days)
+    USERS_TABLE_NAME      = aws_dynamodb_table.users.id
+    AVATARS_BUCKET_NAME   = aws_s3_bucket.avatars.id
+    AVATARS_CDN_URL       = "https://cdn.${local.domain_name}"
+    AVATARS_KMS_KEY_ARN   = aws_kms_alias.web_app.target_key_arn
+    EVENTS_TABLE_NAME     = aws_dynamodb_table.events.id
+    EVENTS_RETENTION_DAYS = tostring(var.events_retention_days)
+    # The pool's lambda_config references the presignup_link Lambda's
+    # ARN; the Lambda must NOT reference the pool's id directly here or
+    # we get a Terraform dependency cycle. Instead, pass the SSM
+    # parameter NAME (a static string) and read the pool ID at cold
+    # start. See users-presignup-link/index.js.
+    USER_POOL_ID_SSM_PARAM = "/xomware/shared/cognito/user-pool-id"
   }
 }
 
@@ -123,6 +136,26 @@ data "aws_iam_policy_document" "users_lambda" {
       "kms:DescribeKey",
     ]
     resources = [aws_kms_alias.web_app.target_key_arn]
+  }
+
+  # Cognito - PreSignUp link trigger (users-presignup-link) needs to look up
+  # native users by email and link a federated identity to the matching
+  # native account. Scoped to the shared xomware-users pool only.
+  statement {
+    effect = "Allow"
+    actions = [
+      "cognito-idp:ListUsers",
+      "cognito-idp:AdminLinkProviderForUser",
+    ]
+    resources = [aws_cognito_user_pool.xomware_users.arn]
+  }
+
+  # SSM - PreSignUp Lambda reads the user pool id from SSM at cold start
+  # (TF dependency cycle prevents passing it through env directly).
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [aws_ssm_parameter.cognito_user_pool_id.arn]
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 4 of the auth epic. Wires Google as a federated identity provider on the shared `xomware-users` Cognito pool, and adds a PreSignUp Lambda trigger that auto-links a federating Google identity to an existing native Cognito user when emails match (no duplicate accounts).

- New IdP resource `aws_cognito_identity_provider.google` (reads client_id/secret from SSM)
- Both app clients (`xomware-com`, `xomappetit`) now list `["COGNITO", "Google"]` in `supported_identity_providers`
- New Lambda `users-presignup-link` wired as the pool's `lambda_config.pre_sign_up`
- IAM additions to `users_lambda` role: `cognito-idp:ListUsers`, `cognito-idp:AdminLinkProviderForUser` (scoped to pool ARN), `ssm:GetParameter` (scoped to user-pool-id param)

## Manual prereq (BEFORE apply)

Terraform apply WILL FAIL until both SSM params exist. Steps for Dom:

1. Google Cloud Console -> APIs & Services -> Credentials -> **Create Credentials -> OAuth client ID**
2. Application type: **Web application**
3. Authorized redirect URIs:
   - `https://xomware-auth.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`
4. Authorized JavaScript origins:
   - `https://xomware.com`
   - `https://xn--xomapptit-g4a.xomware.com`
   - `https://xomappetit.xomware.com`
5. Save, then write to SSM:
   ```bash
   aws ssm put-parameter \
     --name /xomware/shared/google-oauth/client-id \
     --type String \
     --value '<CLIENT_ID>'

   aws ssm put-parameter \
     --name /xomware/shared/google-oauth/client-secret \
     --type SecureString \
     --value '<CLIENT_SECRET>'
   ```
6. Re-run apply.

## Notes / surprises

- A naive wiring caused a Terraform dependency cycle: pool -> Lambda (via `lambda_config.pre_sign_up`) -> Lambda env (USER_POOL_ID) -> pool. Fix: pass the SSM param name (a static string) through env, and have the Lambda fetch the pool id from SSM at cold start. Adds one cached SSM read per cold container — negligible.
- `prevent_user_existence_errors` left ENABLED (security).
- `aws_lambda_permission` for Cognito to invoke the new Lambda mirrors the existing `users_create_cognito` permission.
- All resources tagged via the shared `local.standard_tags` already attached to the lambda for_each block.

## Test plan

- [ ] Dom creates Google OAuth client in GCP and writes SSM params
- [ ] `terraform plan` clean (Add: ~4, Change: ~3 for the two clients + pool lambda_config, Destroy: 0)
- [ ] `terraform apply`
- [ ] Smoke test: hit `https://xomware-auth.auth.us-east-1.amazoncognito.com/oauth2/authorize?identity_provider=Google&...` returns Google consent screen
- [ ] Sign in with a Google account whose email does NOT match any local user -> new user row created via PostConfirmation
- [ ] Sign in with a Google account whose email DOES match a local user -> CloudWatch logs for `users-presignup-link` show "linked Google identity to native user ..." and no duplicate Cognito user is created