### PR TITLE
feat(admin): xomware-events audit table + admin API (Phase 5)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,20 +62,19 @@ jobs:
       - name: Comment PR with Plan
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
         with:
           script: |
-            const plan = `${{ steps.plan.outputs.stdout }}`;
+            const plan = process.env.PLAN_STDOUT || '';
             const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n\n... (truncated)' : plan;
-            const body = `### Terraform Plan 📋
-            \`\`\`
-            ${truncated}
-            \`\`\`
-            *Plan: ${{ steps.plan.outcome }}*`;
-            github.rest.issues.createComment({
+            const body = '### Terraform Plan 📋\n```\n' + truncated + '\n```\n*Plan: ' + process.env.PLAN_OUTCOME + '*';
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              body
             });
 
       - name: Terraform Apply

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -lock=false
+        run: terraform plan -no-color -input=false -lock=false 2>&1 | tee /tmp/tf-plan.txt
         continue-on-error: true
         env:
           TF_VAR_command_center_passphrase_hash: ${{ secrets.COMMAND_CENTER_PASSPHRASE_HASH }}
@@ -63,12 +63,16 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
-          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
         with:
           script: |
-            const plan = process.env.PLAN_STDOUT || '';
-            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n\n... (truncated)' : plan;
+            const fs = require('fs');
+            const raw = fs.existsSync('/tmp/tf-plan.txt')
+              ? fs.readFileSync('/tmp/tf-plan.txt', 'utf8')
+              : '';
+            const truncated = raw.length > 60000
+              ? raw.substring(0, 60000) + '\n\n... (truncated)'
+              : raw;
             const body = '### Terraform Plan 📋\n```\n' + truncated + '\n```\n*Plan: ' + process.env.PLAN_OUTCOME + '*';
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/lambda/admin/admin-cost-summary/index.js
+++ b/lambda/admin/admin-cost-summary/index.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// POST /admin/cost/summary
+// Admin-group only. Pulls month-to-date AWS cost from Cost Explorer,
+// grouped by service. Cost Explorer charges $0.01/request — cache the
+// result for 1 hour in-process.
+//
+// Body: { startDate?: 'YYYY-MM-DD', endDate?: 'YYYY-MM-DD' }
+// Defaults: 1st of current month → today (UTC).
+
+const {
+  CostExplorerClient,
+  GetCostAndUsageCommand,
+} = require('@aws-sdk/client-cost-explorer');
+
+// Cost Explorer is a global service; SDK requires us-east-1 endpoint.
+const ceClient = new CostExplorerClient({ region: 'us-east-1' });
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+};
+const json = (statusCode, body) => ({ statusCode, headers, body: JSON.stringify(body) });
+
+function isAdmin(event) {
+  const claim = event.requestContext?.authorizer?.claims?.['cognito:groups'] || '';
+  if (typeof claim === 'string') {
+    return claim.replace(/^\[|\]$/g, '').split(/,\s*/).includes('admin');
+  }
+  return Array.isArray(claim) && claim.includes('admin');
+}
+
+const cache = { key: null, value: null, expiresAt: 0 };
+
+function defaultRange() {
+  const now = new Date();
+  const start = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`;
+  const end = now.toISOString().slice(0, 10);
+  return { start, end };
+}
+
+exports.handler = async (event) => {
+  if (!isAdmin(event)) return json(403, { error: 'admin group required' });
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const { start: defStart, end: defEnd } = defaultRange();
+    const start = /^\d{4}-\d{2}-\d{2}$/.test(body.startDate) ? body.startDate : defStart;
+    const end = /^\d{4}-\d{2}-\d{2}$/.test(body.endDate) ? body.endDate : defEnd;
+
+    const cacheKey = `${start}~${end}`;
+    if (cache.key === cacheKey && cache.expiresAt > Date.now()) {
+      return json(200, { ...cache.value, cached: true });
+    }
+
+    const result = await ceClient.send(
+      new GetCostAndUsageCommand({
+        TimePeriod: { Start: start, End: end },
+        Granularity: 'MONTHLY',
+        Metrics: ['UnblendedCost'],
+        GroupBy: [{ Type: 'DIMENSION', Key: 'SERVICE' }],
+      })
+    );
+
+    const groups = (result.ResultsByTime?.[0]?.Groups || []).map((g) => ({
+      service: g.Keys?.[0] || 'Unknown',
+      amount: Number(g.Metrics?.UnblendedCost?.Amount || 0),
+      unit: g.Metrics?.UnblendedCost?.Unit || 'USD',
+    }));
+    groups.sort((a, b) => b.amount - a.amount);
+    const total = Number(groups.reduce((s, g) => s + g.amount, 0).toFixed(4));
+
+    const value = { start, end, total, currency: groups[0]?.unit || 'USD', services: groups };
+    cache.key = cacheKey;
+    cache.value = value;
+    cache.expiresAt = Date.now() + 60 * 60 * 1000;
+
+    return json(200, { ...value, cached: false });
+  } catch (err) {
+    console.error('admin-cost-summary error:', err);
+    return json(500, { error: err.message });
+  }
+};

--- a/lambda/admin/admin-events-list/index.js
+++ b/lambda/admin/admin-events-list/index.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// GET-style POST /admin/events/list
+// Admin-group only. Queries the by-day GSI on xomware-events.
+//
+// Body:
+//   { date?: 'YYYY-MM-DD' (default: today UTC),
+//     limit?: number (default 50, max 200),
+//     cursor?: string  (opaque pagination token from a prior response) }
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, QueryCommand } = require('@aws-sdk/lib-dynamodb');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.EVENTS_TABLE_NAME;
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+};
+const json = (statusCode, body) => ({ statusCode, headers, body: JSON.stringify(body) });
+
+function isAdmin(event) {
+  const claim = event.requestContext?.authorizer?.claims?.['cognito:groups'] || '';
+  if (typeof claim === 'string') {
+    return claim.replace(/^\[|\]$/g, '').split(/,\s*/).includes('admin');
+  }
+  return Array.isArray(claim) && claim.includes('admin');
+}
+
+exports.handler = async (event) => {
+  if (!isAdmin(event)) return json(403, { error: 'admin group required' });
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const date = typeof body.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(body.date)
+      ? body.date
+      : new Date().toISOString().slice(0, 10);
+    const limit = Math.min(Math.max(Number(body.limit) || 50, 1), 200);
+    const cursor = typeof body.cursor === 'string' && body.cursor
+      ? JSON.parse(Buffer.from(body.cursor, 'base64').toString('utf8'))
+      : undefined;
+
+    const { Items = [], LastEvaluatedKey } = await docClient.send(
+      new QueryCommand({
+        TableName: TABLE,
+        IndexName: 'by-day',
+        KeyConditionExpression: 'eventDate = :d',
+        ExpressionAttributeValues: { ':d': date },
+        ScanIndexForward: false,
+        Limit: limit,
+        ExclusiveStartKey: cursor,
+      })
+    );
+
+    const nextCursor = LastEvaluatedKey
+      ? Buffer.from(JSON.stringify(LastEvaluatedKey)).toString('base64')
+      : null;
+
+    return json(200, { date, items: Items, nextCursor });
+  } catch (err) {
+    console.error('admin-events-list error:', err);
+    return json(500, { error: err.message });
+  }
+};

--- a/lambda/auth/auth-track/index.js
+++ b/lambda/auth/auth-track/index.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// Cognito PostAuthentication trigger — writes a `signin` event to
+// xomware-events.
+//
+// Failures are swallowed. PostAuthentication blocks the user's sign-in
+// if the trigger throws, and audit logging is non-critical metadata.
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, PutCommand } = require('@aws-sdk/lib-dynamodb');
+const { randomUUID } = require('crypto');
+
+const region = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.EVENTS_TABLE_NAME;
+const RETENTION_DAYS = Number(process.env.EVENTS_RETENTION_DAYS || 90);
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+exports.handler = async (event) => {
+  try {
+    const triggerSource = event && event.triggerSource;
+    if (
+      triggerSource !== 'PostAuthentication_Authentication' &&
+      triggerSource !== 'PostAuthentication_AuthenticationWithFederation'
+    ) {
+      return event;
+    }
+
+    const attrs = (event.request && event.request.userAttributes) || {};
+    const userId = attrs.sub;
+    if (!userId || !TABLE) return event;
+
+    const now = new Date();
+    const eventId = randomUUID();
+    const eventTime = now.toISOString();
+    const eventDate = eventTime.slice(0, 10);
+    const ttl = Math.floor(now.getTime() / 1000) + RETENTION_DAYS * 86400;
+
+    await docClient.send(
+      new PutCommand({
+        TableName: TABLE,
+        Item: {
+          eventId,
+          eventType: 'signin',
+          eventTime,
+          eventDate,
+          eventTimeId: `${eventTime}#${eventId}`,
+          userId,
+          email: attrs.email || null,
+          identityProvider: triggerSource === 'PostAuthentication_AuthenticationWithFederation'
+            ? 'federated'
+            : 'cognito',
+          appClientId: event.callerContext && event.callerContext.clientId,
+          ttl,
+        },
+      })
+    );
+  } catch (err) {
+    console.error('auth-track: failed to write signin event', err && err.name, err && err.message);
+  }
+  return event;
+};

--- a/lambda/users/users-create/index.js
+++ b/lambda/users/users-create/index.js
@@ -1,18 +1,52 @@
 'use strict';
 
 // Cognito PostConfirmation trigger.
-// On email-verified signup, write a user row to xomware-users.
-// Idempotent via attribute_not_exists(userId) condition.
+// On email-verified signup, write a user row to xomware-users AND a
+// signup event row to xomware-events for the /admin portal audit log.
+// Both writes are best-effort — failures don't block the user.
 
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, PutCommand } = require('@aws-sdk/lib-dynamodb');
+const { randomUUID } = require('crypto');
 
 const region = process.env.AWS_REGION || 'us-east-1';
 const TABLE = process.env.USERS_TABLE_NAME;
+const EVENTS_TABLE = process.env.EVENTS_TABLE_NAME;
+const RETENTION_DAYS = Number(process.env.EVENTS_RETENTION_DAYS || 90);
 
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
   marshallOptions: { removeUndefinedValues: true },
 });
+
+async function writeSignupEvent({ userId, email, identityProvider, clientId }) {
+  if (!EVENTS_TABLE) return;
+  const now = new Date();
+  const eventId = randomUUID();
+  const eventTime = now.toISOString();
+  const eventDate = eventTime.slice(0, 10);
+  const ttl = Math.floor(now.getTime() / 1000) + RETENTION_DAYS * 86400;
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: EVENTS_TABLE,
+        Item: {
+          eventId,
+          eventType: 'signup',
+          eventTime,
+          eventDate,
+          eventTimeId: `${eventTime}#${eventId}`,
+          userId,
+          email: email || null,
+          identityProvider: identityProvider || 'cognito',
+          appClientId: clientId,
+          ttl,
+        },
+      }),
+    );
+  } catch (err) {
+    console.error('users-create: failed to write signup event', err && err.name, err && err.message);
+  }
+}
 
 exports.handler = async (event) => {
   // Always return event back to Cognito, even on failure — failing this trigger
@@ -57,20 +91,38 @@ exports.handler = async (event) => {
       lastSeenAt: now,
     };
 
-    await docClient.send(
-      new PutCommand({
-        TableName: TABLE,
-        Item: row,
-        ConditionExpression: 'attribute_not_exists(userId)',
-      }),
-    );
-    console.log('users-create: created row for', userId);
-  } catch (err) {
-    if (err && err.name === 'ConditionalCheckFailedException') {
-      console.log('users-create: row already exists, skipping');
-    } else {
-      console.error('users-create: error writing row', err);
+    let createdNew = false;
+    try {
+      await docClient.send(
+        new PutCommand({
+          TableName: TABLE,
+          Item: row,
+          ConditionExpression: 'attribute_not_exists(userId)',
+        }),
+      );
+      createdNew = true;
+      console.log('users-create: created row for', userId);
+    } catch (err) {
+      if (err && err.name === 'ConditionalCheckFailedException') {
+        console.log('users-create: row already exists, skipping');
+      } else {
+        console.error('users-create: error writing row', err);
+      }
     }
+
+    // Only emit the signup event when the row didn't already exist —
+    // PostConfirmation also fires for password-reset confirmations
+    // (handled above) and on idempotent retries.
+    if (createdNew) {
+      await writeSignupEvent({
+        userId,
+        email,
+        identityProvider: 'cognito',
+        clientId: event.callerContext && event.callerContext.clientId,
+      });
+    }
+  } catch (err) {
+    console.error('users-create: outer error', err);
   }
 
   return event;

--- a/terraform/api_users.tf
+++ b/terraform/api_users.tf
@@ -75,6 +75,21 @@ locals {
     },
   ]
 
+  admin_endpoints = [
+    {
+      name        = "events-list"
+      path_part   = "events-list"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.admin["events_list"].invoke_arn
+    },
+    {
+      name        = "cost-summary"
+      path_part   = "cost-summary"
+      http_method = "POST"
+      invoke_arn  = aws_lambda_function.admin["cost_summary"].invoke_arn
+    },
+  ]
+
   users_allow_origins = join(",", [
     "https://xomware.com",
     "https://xn--xomapptit-g4a.xomware.com",
@@ -114,6 +129,10 @@ module "users_api" {
     users = {
       path_prefix = "users"
       endpoints   = local.users_endpoints
+    }
+    admin = {
+      path_prefix = "admin"
+      endpoints   = local.admin_endpoints
     }
   }
 }

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -259,3 +259,20 @@ resource "aws_cognito_user_group" "admin" {
   description  = "Xomware admin group — full access to /admin portal"
   precedence   = 1
 }
+
+# Admin membership — lift each Cognito sub from `var.admin_user_subs` into
+# the admin group. Default list is empty; populate via terraform.tfvars
+# AFTER your first signup (find your sub on the /profile page or by
+# decoding your JWT). Re-apply to grant.
+variable "admin_user_subs" {
+  description = "Cognito subs (UUIDs) to put in the admin group"
+  type        = list(string)
+  default     = []
+}
+
+resource "aws_cognito_user_in_group" "admins" {
+  for_each     = toset(var.admin_user_subs)
+  user_pool_id = aws_cognito_user_pool.xomware_users.id
+  group_name   = aws_cognito_user_group.admin.name
+  username     = each.value
+}

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -116,8 +116,12 @@ resource "aws_cognito_user_pool" "xomware_users" {
   # Phase 3: PostConfirmation Lambda trigger writes the user row to
   # xomware-users on email-verified signup. Per AWS provider docs this is an
   # in-place update (NOT replacement). See lambdas_users.tf for the Lambda.
+  #
+  # Phase 5: PostAuthentication trigger writes a `signin` event to
+  # xomware-events for the /admin portal audit log.
   lambda_config {
-    post_confirmation = aws_lambda_function.users["create"].arn
+    post_confirmation    = aws_lambda_function.users["create"].arn
+    post_authentication  = aws_lambda_function.auth_track.arn
   }
 
   tags = merge(local.standard_tags, {
@@ -136,6 +140,15 @@ resource "aws_lambda_permission" "users_create_cognito" {
   statement_id  = "AllowCognitoInvokeUsersCreate"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.users["create"].function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.xomware_users.arn
+}
+
+# Allow Cognito to invoke the auth-track PostAuthentication lambda.
+resource "aws_lambda_permission" "auth_track_cognito" {
+  statement_id  = "AllowCognitoInvokeAuthTrack"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.auth_track.function_name
   principal     = "cognito-idp.amazonaws.com"
   source_arn    = aws_cognito_user_pool.xomware_users.arn
 }

--- a/terraform/dynamodb_events.tf
+++ b/terraform/dynamodb_events.tf
@@ -1,0 +1,96 @@
+#**********************
+# Events / audit log — `xomware-events`
+#
+# Append-only audit table written by Cognito triggers (signup, signin) and
+# read by the /admin portal. TTL = 90 days to keep storage near-free at
+# hobby scale; tighten/loosen via `events_retention_days`.
+#
+# Access patterns:
+#   - by day:   `eventDate` (YYYY-MM-DD) sorted by `eventTime#eventId`
+#   - by user:  `userId`                  sorted by `eventTime#eventId`
+#   - by type:  `eventType`               sorted by `eventTime#eventId`
+#
+# All sort keys are `eventTime#eventId` so DynamoDB sorts lexicographically
+# by ISO-8601 timestamp, then de-duplicates within the same instant via the
+# trailing eventId.
+#**********************
+
+resource "aws_dynamodb_table" "events" {
+  name         = "${var.app_name}-events"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "eventId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.web_app.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  attribute {
+    name = "eventId"
+    type = "S"
+  }
+
+  attribute {
+    name = "eventDate"
+    type = "S"
+  }
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  attribute {
+    name = "eventType"
+    type = "S"
+  }
+
+  attribute {
+    name = "eventTimeId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "by-day"
+    hash_key        = "eventDate"
+    range_key       = "eventTimeId"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "by-user"
+    hash_key        = "userId"
+    range_key       = "eventTimeId"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "by-type"
+    hash_key        = "eventType"
+    range_key       = "eventTimeId"
+    projection_type = "ALL"
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-events"
+    "environment" = "shared"
+    "owner"       = "xomware"
+    "purpose"     = "audit"
+  })
+}
+
+# Retention window for audit rows (TTL). 90 days is plenty for hobby scale
+# usage analytics; raise to capture longer trends.
+variable "events_retention_days" {
+  type    = number
+  default = 90
+}

--- a/terraform/lambdas_admin.tf
+++ b/terraform/lambdas_admin.tf
@@ -1,0 +1,166 @@
+#**********************
+# Admin / audit Lambdas
+#
+#   - auth-track          Cognito PostAuthentication trigger -> events
+#   - admin-events-list   POST /admin/events/list (admin-group)
+#   - admin-cost-summary  POST /admin/cost/summary (admin-group)
+#
+# All three share the admin IAM role:
+#   * dynamodb read+write on xomware-events
+#   * ce:GetCostAndUsage  (admin-cost-summary only — kept on shared role
+#     because the read is harmless and a separate role doubles infra)
+#**********************
+
+locals {
+  admin_lambdas = {
+    events_list = {
+      name        = "admin-events-list"
+      description = "Admin: list audit events by day"
+      source_dir  = "${path.module}/../lambda/admin/admin-events-list"
+    }
+    cost_summary = {
+      name        = "admin-cost-summary"
+      description = "Admin: month-to-date cost from Cost Explorer"
+      source_dir  = "${path.module}/../lambda/admin/admin-cost-summary"
+      timeout     = 30
+    }
+  }
+
+  admin_lambda_env = {
+    EVENTS_TABLE_NAME     = aws_dynamodb_table.events.id
+    EVENTS_RETENTION_DAYS = tostring(var.events_retention_days)
+  }
+}
+
+# --- IAM: shared role for all 3 admin/auth lambdas ---
+
+data "aws_iam_policy_document" "admin_lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "admin_lambda" {
+  name               = "${var.app_name}-admin-lambdas"
+  assume_role_policy = data.aws_iam_policy_document.admin_lambda_assume.json
+  tags               = merge(local.standard_tags, { "name" = "${var.app_name}-admin-lambdas" })
+}
+
+resource "aws_iam_role_policy_attachment" "admin_lambda_basic" {
+  role       = aws_iam_role.admin_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "admin_lambda" {
+  # Events table — write (auth-track) + query GSIs (events-list).
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:GetItem",
+      "dynamodb:DescribeTable",
+    ]
+    resources = [
+      aws_dynamodb_table.events.arn,
+      "${aws_dynamodb_table.events.arn}/index/*",
+    ]
+  }
+
+  # Events table is KMS-encrypted under the web_app key.
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
+    resources = [aws_kms_alias.web_app.target_key_arn]
+  }
+
+  # Cost Explorer — read-only.
+  statement {
+    effect    = "Allow"
+    actions   = ["ce:GetCostAndUsage", "ce:GetCostForecast"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "admin_lambda" {
+  name   = "${var.app_name}-admin-lambdas-policy"
+  role   = aws_iam_role.admin_lambda.id
+  policy = data.aws_iam_policy_document.admin_lambda.json
+}
+
+# --- auth-track (PostAuthentication trigger) ---
+
+data "archive_file" "auth_track" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda/auth/auth-track"
+  output_path = "${path.module}/../lambda/auth/auth-track.zip"
+}
+
+resource "aws_lambda_function" "auth_track" {
+  function_name    = "${var.app_name}-auth-track"
+  description      = "Cognito PostAuthentication: write signin event"
+  role             = aws_iam_role.admin_lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs20.x"
+  timeout          = 10
+  memory_size      = 256
+  filename         = data.archive_file.auth_track.output_path
+  source_code_hash = data.archive_file.auth_track.output_base64sha256
+
+  environment {
+    variables = local.admin_lambda_env
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-auth-track"
+    "environment" = "shared"
+    "owner"       = "xomware"
+    "lambda_type" = "auth"
+  })
+}
+
+# --- admin/* API lambdas ---
+
+data "archive_file" "admin" {
+  for_each    = local.admin_lambdas
+  type        = "zip"
+  source_dir  = each.value.source_dir
+  output_path = "${path.module}/../lambda/admin/${each.value.name}.zip"
+}
+
+resource "aws_lambda_function" "admin" {
+  for_each = local.admin_lambdas
+
+  function_name    = "${var.app_name}-${each.value.name}"
+  description      = each.value.description
+  role             = aws_iam_role.admin_lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs20.x"
+  timeout          = lookup(each.value, "timeout", 10)
+  memory_size      = 256
+  filename         = data.archive_file.admin[each.key].output_path
+  source_code_hash = data.archive_file.admin[each.key].output_base64sha256
+
+  environment {
+    variables = local.admin_lambda_env
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"        = "${var.app_name}-${each.value.name}"
+    "environment" = "shared"
+    "owner"       = "xomware"
+    "lambda_type" = "admin"
+  })
+}

--- a/terraform/lambdas_users.tf
+++ b/terraform/lambdas_users.tf
@@ -45,10 +45,12 @@ locals {
   }
 
   users_lambda_env = {
-    USERS_TABLE_NAME    = aws_dynamodb_table.users.id
-    AVATARS_BUCKET_NAME = aws_s3_bucket.avatars.id
-    AVATARS_CDN_URL     = "https://cdn.${local.domain_name}"
-    AVATARS_KMS_KEY_ARN = aws_kms_alias.web_app.target_key_arn
+    USERS_TABLE_NAME       = aws_dynamodb_table.users.id
+    AVATARS_BUCKET_NAME    = aws_s3_bucket.avatars.id
+    AVATARS_CDN_URL        = "https://cdn.${local.domain_name}"
+    AVATARS_KMS_KEY_ARN    = aws_kms_alias.web_app.target_key_arn
+    EVENTS_TABLE_NAME      = aws_dynamodb_table.events.id
+    EVENTS_RETENTION_DAYS  = tostring(var.events_retention_days)
   }
 }
 
@@ -91,6 +93,13 @@ data "aws_iam_policy_document" "users_lambda" {
       aws_dynamodb_table.users.arn,
       "${aws_dynamodb_table.users.arn}/index/*",
     ]
+  }
+
+  # users-create writes signup events on PostConfirmation.
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:PutItem"]
+    resources = [aws_dynamodb_table.events.arn]
   }
 
   # S3 - presigned PUT signing requires the signer's role to have PutObject

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -2,3 +2,7 @@
 # terraform.tfvars is gitignored — never commit secrets
 
 command_center_passphrase_hash = ""
+
+# Cognito subs for the /admin portal. Find your sub on /profile or by
+# decoding your JWT (jwt.io). Re-apply after you set this.
+# admin_user_subs = ["00000000-0000-0000-0000-000000000000"]


### PR DESCRIPTION
## Summary
- **xomware-events** audit table (90-day TTL) with GSIs by-day, by-user, by-type.
- **Cognito triggers** writing signup + signin events.
- **Admin API** under `api.xomware.com/admin/*`: events-list + cost-summary, both gated on the `admin` Cognito group.

## What's wired
| Endpoint | Lambda | Notes |
|---|---|---|
| (PostAuthentication) | `xomware-auth-track` | Writes \`{eventType: 'signin'}\` per login |
| (PostConfirmation, extended) | `xomware-users-create` | Now also writes \`{eventType: 'signup'}\` on first row creation |
| POST /admin/events-list | `xomware-admin-events-list` | by-day GSI, opaque cursor pagination |
| POST /admin/cost-summary | `xomware-admin-cost-summary` | Cost Explorer MTD by service, cached 1h in-process |

## Auth gate
All admin lambdas read \`cognito:groups\` from the JWT and 403 without \`admin\`. The group resource (\`aws_cognito_user_group.admin\`) already exists. Add yourself via:
\`\`\`
aws cognito-idp admin-add-user-to-group --user-pool-id <id> --username <your-sub> --group-name admin
\`\`\`

## Cost
- Events table is PAY_PER_REQUEST + KMS + 90-day TTL — effectively free at hobby scale.
- Cost Explorer charges \$0.01/request. The lambda caches per-day-range for 1 hour in-process to amortize across admin page reloads. Worst case: ~\$0.24/day if every minute someone hits a unique range.

## Not in this PR
- Frontend (xomware.com/admin Angular page) — follow-up.
- Backfill of historical signups (no Cognito API for this; events start from deploy).
- SES alerting on suspicious patterns — out of scope.

## Test plan
- [ ] \`terraform apply\` — expect 1 new table, 3 new lambdas, 1 IAM role+policy, 2 new API Gateway resources, +1 attribute on existing users-create env.
- [ ] Sign in once -> confirm a row appears in xomware-events with eventType=signin.
- [ ] Sign up a fresh user -> row with eventType=signup.
- [ ] Add yourself to \`admin\` group; \`POST /admin/events-list\` returns today's rows.
- [ ] \`POST /admin/cost-summary\` returns MTD cost grouped by service.
- [ ] Hit either endpoint without admin group -> 403.