### PR TITLE
fix: JIT-create user row on /users/me + grant Dom admin

### DIFF
--- a/lambda/users/users-me/index.js
+++ b/lambda/users/users-me/index.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
-const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+const {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} = require('@aws-sdk/lib-dynamodb');
 
 const region = process.env.AWS_REGION || 'us-east-1';
 const TABLE = process.env.USERS_TABLE_NAME;
@@ -23,36 +28,78 @@ function json(statusCode, body) {
   };
 }
 
-function getUserId(event) {
-  const claims =
-    event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims;
-  return claims && claims.sub ? claims.sub : null;
+function getClaims(event) {
+  return (event && event.requestContext && event.requestContext.authorizer && event.requestContext.authorizer.claims) || null;
+}
+
+// Build a fresh user row from JWT claims. Used to JIT-provision federated
+// users whose Cognito flow skips PostConfirmation (Google sign-up never
+// fires it). Native users get their row from the users-create
+// PostConfirmation trigger and never hit this path.
+function rowFromClaims(claims) {
+  const now = new Date().toISOString();
+  const fullName = claims.name || [claims.given_name, claims.family_name].filter(Boolean).join(' ') || null;
+  return {
+    userId: claims.sub,
+    email: claims.email || null,
+    preferredUsername: null,
+    displayName: fullName,
+    avatarUrl: claims.picture || null,
+    profileVisibility: 'public',
+    createdAt: now,
+    lastSeenAt: now,
+  };
 }
 
 exports.handler = async (event) => {
-  const userId = getUserId(event);
+  const claims = getClaims(event);
+  const userId = claims && claims.sub;
   if (!userId) return json(401, { error: 'unauthorized' });
 
   try {
     const { Item } = await docClient.send(
       new GetCommand({ TableName: TABLE, Key: { userId } }),
     );
-    if (!Item) return json(404, { error: 'user_not_found' });
 
-    // Fire-and-forget lastSeenAt update — don't block the response.
-    const now = new Date().toISOString();
-    docClient
-      .send(
-        new UpdateCommand({
+    if (Item) {
+      // Fire-and-forget lastSeenAt update — don't block the response.
+      const now = new Date().toISOString();
+      docClient
+        .send(
+          new UpdateCommand({
+            TableName: TABLE,
+            Key: { userId },
+            UpdateExpression: 'SET lastSeenAt = :now',
+            ExpressionAttributeValues: { ':now': now },
+          }),
+        )
+        .catch((err) => console.error('users-me: lastSeenAt update failed', err));
+      return json(200, Item);
+    }
+
+    // JIT-provision: federated users (Google) bypass PostConfirmation, so
+    // first /users/me hit creates their row from the JWT claims.
+    const row = rowFromClaims(claims);
+    try {
+      await docClient.send(
+        new PutCommand({
           TableName: TABLE,
-          Key: { userId },
-          UpdateExpression: 'SET lastSeenAt = :now',
-          ExpressionAttributeValues: { ':now': now },
+          Item: row,
+          ConditionExpression: 'attribute_not_exists(userId)',
         }),
-      )
-      .catch((err) => console.error('users-me: lastSeenAt update failed', err));
-
-    return json(200, Item);
+      );
+      console.log('users-me: JIT-created row for', userId);
+    } catch (putErr) {
+      // Race: row created between Get and Put. Re-read.
+      if (putErr && putErr.name === 'ConditionalCheckFailedException') {
+        const reread = await docClient.send(
+          new GetCommand({ TableName: TABLE, Key: { userId } }),
+        );
+        return json(200, reread.Item || row);
+      }
+      throw putErr;
+    }
+    return json(200, row);
   } catch (err) {
     console.error('users-me error', err);
     return json(500, { error: 'internal_error' });

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -286,9 +286,14 @@ resource "aws_cognito_user_group" "admin" {
 # AFTER your first signup (find your sub on the /profile page or by
 # decoding your JWT). Re-apply to grant.
 variable "admin_user_subs" {
-  description = "Cognito subs (UUIDs) to put in the admin group"
+  description = "Cognito usernames to put in the admin group. Native users: opaque UUID Username (== sub). Federated users: <provider>_<external-id>, e.g. Google_102793155679129129113594."
   type        = list(string)
-  default     = []
+  default = [
+    # Dom's Google-federated identity. Cognito Username, not the sub —
+    # aws_cognito_user_in_group.username takes the Username field, which
+    # for federated users is `<provider>_<external-id>`.
+    "Google_102793155679129129113594",
+  ]
 }
 
 resource "aws_cognito_user_in_group" "admins" {


### PR DESCRIPTION
Two fixes from first Google sign-in:

1. **`/users/me` 404'd.** Cognito skips PostConfirmation on federated sign-ups (Google), so no row was created in xomware-users. Native users still flow through the users-create trigger; federated users now get JIT-provisioned on their first `/users/me` hit, populating displayName + avatar from the Google JWT claims. Idempotent via `attribute_not_exists(userId)`.

2. **Admin grant.** Add Dom's Google-federated Cognito Username (`Google_102793155679129129113594`) to the default `admin_user_subs`. Variable description updated to clarify it holds Cognito Usernames, not subs (federated form is `<provider>_<external-id>`).