### PR TITLE
fix: revert bad admin grant default (federated username 404'd)

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -286,14 +286,9 @@ resource "aws_cognito_user_group" "admin" {
 # AFTER your first signup (find your sub on the /profile page or by
 # decoding your JWT). Re-apply to grant.
 variable "admin_user_subs" {
-  description = "Cognito usernames to put in the admin group. Native users: opaque UUID Username (== sub). Federated users: <provider>_<external-id>, e.g. Google_102793155679129129113594."
+  description = "Cognito usernames to put in the admin group. Use the opaque UUID Username for native users (same as the JWT sub claim). Federated users get linked to a native account by PreSignUp_ExternalProvider, so even Google sign-ins resolve to the native Username — never the `Google_<id>` form."
   type        = list(string)
-  default = [
-    # Dom's Google-federated identity. Cognito Username, not the sub —
-    # aws_cognito_user_in_group.username takes the Username field, which
-    # for federated users is `<provider>_<external-id>`.
-    "Google_102793155679129129113594",
-  ]
+  default     = []
 }
 
 resource "aws_cognito_user_in_group" "admins" {


### PR DESCRIPTION
Apply for #36 failed: `AdminAddUserToGroup` returned UserNotFoundException for `Google_102793155679129129113594`. PreSignUp_ExternalProvider links the Google identity onto Dom's existing native account, so the federated 'Google_<id>' form doesn't exist as a standalone Cognito Username — it's an attached identity.

Empty the default. Real grant comes from a tfvars override using the native Username (== JWT sub), which the user can find on /profile once the JIT-create lambda from #36 lands. The lambda code change from #36 is already on master.